### PR TITLE
Use new actions on local attest

### DIFF
--- a/.github/workflows/local_attest.yml
+++ b/.github/workflows/local_attest.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       contents: write # needed for storing the vsa in the repo.
       id-token: write
-    uses: slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@main
+    uses: slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@main


### PR DESCRIPTION
This PR updates the local_attest workflow to dispatch the run to the new actions repository at slsa-framework/source-actions.

:warning: Once this merges, all attestations in this repo will be signed with the new repo identity from that point on, which may lead to problems. See: https://github.com/slsa-framework/slsa-source-poc/issues/255

