### PR TITLE
Repository rename tasks

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2025 The SLSA Authors
+# SPDX-License-Identifier: Apache-2.0
+---
 name: Go Tests (sourcetool)
 
 on:

--- a/.github/workflows/local_attest.yml
+++ b/.github/workflows/local_attest.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2025 The SLSA Authors
+# SPDX-License-Identifier: Apache-2.0
+---
 name: SLSA Source
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2025 The SLSA Authors
+# SPDX-License-Identifier: Apache-2.0
+---
 name: release
 
 on:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,7 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/slsa-framework/slsa-source-poc)
+        - prefix(github.com/slsa-framework/source-tool)
 linters:
   enable:
     - asasalint

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -10,4 +10,4 @@ plugins:
     out: ./pkg
     opt: 
       - paths=import
-      - module=github.com/slsa-framework/slsa-source-poc/pkg
+      - module=github.com/slsa-framework/source-tool/pkg

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -181,7 +181,7 @@ field in the policy then needs to be enabled too.
 TODO: In the future this tool could be updated to allow some subset of tags
 to be updated (e.g. `latest`, `nightly`), but that feature is not yet
 supported. Tracked
-[here](https://github.com/slsa-framework/slsa-source-poc/issues/129).
+[here](https://github.com/slsa-framework/source-tool/issues/129).
 
 The tag hygiene control is evaluated for _both_ branch updates and tag updates.
 
@@ -243,7 +243,7 @@ Source provenance covers changes to a branch.  It indicates:
       }
     }
   ],
-  "predicateType": "https://github.com/slsa-framework/slsa-source-poc/source-provenance/v1-draft",
+  "predicateType": "https://github.com/slsa-framework/source-tool/source-provenance/v1-draft",
   "predicate": {
     "activity_type": "pr_merge",
     "actor": "TomHennen",
@@ -268,7 +268,7 @@ Source provenance covers changes to a branch.  It indicates:
     ],
     "created_on": "2025-05-31T21:52:36.665624162Z",
     "prev_commit": "a224aa2d55884ef0cef78ccb498c3561ca240808",
-    "repo_uri": "https://github.com/slsa-framework/slsa-source-poc"
+    "repo_uri": "https://github.com/slsa-framework/source-tool"
   }
 }
 ```
@@ -306,7 +306,7 @@ Tag provenance records a tag creation event.  It indicates:
       }
     ],
     "created_on": "2025-06-01T21:46:21.698144672Z",
-    "repo_uri": "https://github.com/slsa-framework/slsa-source-poc",
+    "repo_uri": "https://github.com/slsa-framework/source-tool",
     "tag": "refs/tags/sourcetool/v0.5.1",
     "vsa_summaries": [
       {
@@ -326,8 +326,8 @@ Tag provenance records a tag creation event.  It indicates:
 
 ## Policy
 
-This PoC uses user supplied 'policy' files (stored in
-[a public git repo](https://github.com/slsa-framework/slsa-source-poc/tree/main/policy/github.com)
+This PoC uses user-supplied 'policy' files (stored in
+[a public git repo](https://github.com/slsa-framework/source-policies/tree/main/policy/github.com)
 outside of user control) to indicate what controls _ought_ to be enforced and when that
 enforcement should start.
 
@@ -340,7 +340,7 @@ This amounts to public declaration of SLSA adoption and allows backsliding to be
 
 ```json
 {
-  "canonical_repo": "https://github.com/slsa-framework/slsa-source-poc",
+  "canonical_repo": "https://github.com/slsa-framework/source-tool",
   "protected_branches": [
     {
       "Name": "main",
@@ -370,7 +370,7 @@ declaration by the org that all tags are protected.
 
 The tool does not yet support protecting only some tags. Adding support is
 tracked in
-[this issue](https://github.com/slsa-framework/slsa-source-poc/issues/129).
+[this issue](https://github.com/slsa-framework/source-tool/issues/129).
 
 ### Org Specified Properties
 
@@ -403,9 +403,9 @@ Example VSA
   "predicateType": "https://slsa.dev/verification_summary/v1",
   "predicate": {
     "policy": {
-      "uri": "https://github.com/slsa-framework/slsa-source-poc/blob/main/policy/github.com/slsa-framework/slsa-source-poc/source-policy.json"
+      "uri": "https://github.com/slsa-framework/source-policies/blob/main/policy/github.com/slsa-framework/source-tool/source-policy.json"
     },
-    "resourceUri": "git+https://github.com/slsa-framework/slsa-source-poc",
+    "resourceUri": "git+https://github.com/slsa-framework/source-tool",
     "timeVerified": "2025-06-01T21:51:51.451207508Z",
     "verificationResult": "PASSED",
     "verifiedLevels": [
@@ -414,7 +414,7 @@ Example VSA
       "ORG_SOURCE_TESTED"
     ],
     "verifier": {
-      "id": "https://github.com/slsa-framework/slsa-source-poc"
+      "id": "https://github.com/slsa-framework/source-tool"
     }
   }
 }

--- a/docs/REQUIREMENTS_MAPPING.md
+++ b/docs/REQUIREMENTS_MAPPING.md
@@ -10,7 +10,7 @@ as of June 21, 2025.
 ## Organization Requirements
 
 These requirements are primarily for the organization that is producing the
-source code. The `slsa-source-poc` tool helps organizations meet these
+source code. `source-tool` helps organizations meet these
 requirements when using GitHub as their Source Control System (SCS).
 
 ### [Choose an appropriate source control system](https://slsa.dev/spec/v1.2-rc1/source-requirements#choose-scs)
@@ -18,17 +18,17 @@ requirements when using GitHub as their Source Control System (SCS).
 **Required for: SLSA Source Level 1+**
 
 This requirement is for the organization to select an SCS that can meet their
-desired SLSA Source Level. The `slsa-source-poc` tool is designed specifically
+desired SLSA Source Level. `source-tool` is designed specifically
 for organizations using **GitHub**.
 
 ### [Protect consumable branches and tags](https://slsa.dev/spec/v1.2-rc1/source-requirements#protect-consumable-branches-and-tags)
 
 **Required for: SLSA Source Level 2+**
 
-The `slsa-source-poc` tool is designed around this principle.
+The SLSA source tool is designed around this principle.
 
 - **Policy:** Users define a
-  [policy file](https://github.com/slsa-framework/slsa-source-poc/blob/main/DESIGN.md#policy)
+  [policy file](DESIGN.md#policy)
   to specify which branches are protected and what their target SLSA level is.
   The policy also allows for specifying which tags should be protected.
 - **Identity Management:** The tool relies on GitHub's built-in
@@ -36,7 +36,7 @@ The `slsa-source-poc` tool is designed around this principle.
   to configure which actors can perform sensitive actions.
 - **Technical Controls:** The tool enforces technical controls via GitHub's
   [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository).
-  [DESIGN.md](https://github.com/slsa-framework/slsa-source-poc/blob/main/DESIGN.md)
+  [DESIGN.md](DESIGN.md)
   outlines several controls such as `CONTINUITY_ENFORCED`, `REVIEW_ENFORCED`,
   `TAG_HYGIENE`, and custom `GH_REQUIRED_CHECK_*` controls that map to
   organization-defined checks. These are included in the generated VSAs as
@@ -46,7 +46,7 @@ The `slsa-source-poc` tool is designed around this principle.
 
 **Required for: SLSA Source Level 2+**
 
-The `slsa-source-poc` tool does not provide a technical enforcement mechanism
+The SLSA source tool does not provide a technical enforcement mechanism
 for a safe expunging process. However, it recommends a process based on GitHub's
 features:
 
@@ -62,16 +62,15 @@ used only for safe expunging. This relies on organizational process.
 
 ## Source Control System Requirements
 
-These requirements are for the Source Control System itself. The
-`slsa-source-poc` tool leverages GitHub's capabilities to meet these
-requirements.
+These requirements are for the Source Control System itself. `source-tool`
+leverages GitHub's capabilities to meet these requirements.
 
 ### [Repositories are uniquely identifiable](https://slsa.dev/spec/v1.2-rc1/source-requirements#repository-ids)
 
 **Required for: SLSA Source Level 1+**
 
 The tool works with **GitHub repositories**, which are uniquely identified by
-their URL (e.g., `https://github.com/slsa-framework/slsa-source-poc`).
+their URL (e.g., `https://github.com/slsa-framework/source-tool`).
 
 ### [Revisions are immutable and uniquely identifiable](https://slsa.dev/spec/v1.2-rc1/source-requirements#revision-ids)
 
@@ -84,8 +83,8 @@ identified by their commit hash.
 
 **Required for: SLSA Source Level 1+**
 
-The `slsa-source-poc` tool generates
-[Verification Summary Attestations (VSAs)](https://github.com/slsa-framework/slsa-source-poc/blob/main/DESIGN.md#verification-summary-attestations-vsa)
+The SLSA Source tool generates
+[Verification Summary Attestations (VSAs)](DESIGN.md#verification-summary-attestations-vsa)
 for each commit on a protected branch. These VSAs indicate the SLSA Source Level
 of the revision. The tool uses its generated
 [source provenance](#source-provenance) to issue these VSAs for Level 3 and
@@ -97,7 +96,7 @@ can access the revision.
 **Required for: SLSA Source Level 2+**
 
 The tool requires users to specify protected branches in the
-[policy file](https://github.com/slsa-framework/slsa-source-poc/blob/main/DESIGN.md#policy).
+[policy file](DESIGN.md#policy).
 The tool's logic for determining SLSA levels is then applied to these branches.
 
 ### [History](https://slsa.dev/spec/v1.2-rc1/source-requirements#history)
@@ -113,7 +112,7 @@ tampering with the history of protected branches.
 
 **Required for: SLSA Source Level 2+**
 
-The `slsa-source-poc` tool enforces the change management process through a
+`source-tool` tool enforces the change management process through a
 combination of its policy file and GitHub's rulesets.
 
 - The tool checks for the enforcement of specific rules on protected branches.
@@ -128,12 +127,12 @@ combination of its policy file and GitHub's rulesets.
 
 **Required for: SLSA Source Level 2+**
 
-Continuity is a core concept in the `slsa-source-poc` design.
+Continuity is a core concept in the `source-tool` design.
 
 - The `CONTINUITY_ENFORCED` control ensures that history protection rules are
   continuously enforced.
 - The
-  [provenance-based approach](https://github.com/slsa-framework/slsa-source-poc/blob/main/DESIGN.md#provenance-based)
+  [provenance-based approach](DESIGN.md#provenance-based)
   is designed to track continuity of controls from one commit to the next. If a
   prior commit's provenance shows the same level of control, the start time of
   that control is carried forward. This ensures that there are no gaps in
@@ -149,7 +148,7 @@ require this for a given SLSA level.
 
 **Gap:** The tool does not yet support protecting only a subset of tags; the
 `tag_hygiene` setting applies to all tags. This is tracked in
-[issue #129](https://github.com/slsa-framework/slsa-source-poc/issues/129).
+[issue #129](https://github.com/slsa-framework/source-tool/issues/129).
 
 ### [Identity Management](https://slsa.dev/spec/v1.2-rc1/source-requirements#identity-management)
 
@@ -163,9 +162,9 @@ their GitHub user accounts.
 
 **Required for: SLSA Source Level 3+**
 
-For Level 3, the `slsa-source-poc` tool creates **source provenance
-attestations** for each push to a protected branch. The
-[design document](https://github.com/slsa-framework/slsa-source-poc/blob/main/DESIGN.md#source-provenance)
+For Level 3, `source-tool` creates **source provenance attestations** for each
+push to a protected branch. The
+[design document](DESIGN.md#source-provenance)
 specifies the format of these attestations, which include the actor, the current
 and previous commits, the controls in place, and timestamps.
 
@@ -179,8 +178,8 @@ anyone who can access the revision.
 
 **Required for: SLSA Source Level 4**
 
-For Level 4, the `slsa-source-poc` tool has a `REVIEW_ENFORCED` control. This
-control checks that the repository is configured to:
+For Level 4, `source-tool` has a `REVIEW_ENFORCED` control. This control checks
+that the repository is configured to:
 
 - Require Pull Requests.
 - Require at least one approval.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/slsa-framework/slsa-source-poc
+module github.com/slsa-framework/source-tool
 
 go 1.24.5
 

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/audit"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/audit"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
 )
 
 type AuditMode int

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/auth"
 )
 
 var colorHiRed = color.New(color.FgHiRed).SprintFunc()

--- a/internal/cmd/checklevel.go
+++ b/internal/cmd/checklevel.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/policy"
 )
 
 type checkLevelOpts struct {

--- a/internal/cmd/checklevelprov.go
+++ b/internal/cmd/checklevelprov.go
@@ -13,10 +13,10 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/policy"
 )
 
 type checkLevelProvOpts struct {

--- a/internal/cmd/checktag.go
+++ b/internal/cmd/checktag.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/policy"
 )
 
 type checkTagOptions struct {

--- a/internal/cmd/createpolicy.go
+++ b/internal/cmd/createpolicy.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/policy"
 )
 
 type createPolicyOptions struct {
@@ -23,7 +23,7 @@ func (cpo *createPolicyOptions) Validate() error {
 
 func (cpo *createPolicyOptions) AddFlags(cmd *cobra.Command) {
 	cpo.branchOptions.AddFlags(cmd)
-	cmd.PersistentFlags().StringVar(&cpo.policyRepoPath, "policy_repo_path", "./", "Path to the directory with a clean clone of github.com/slsa-framework/slsa-source-poc.")
+	cmd.PersistentFlags().StringVar(&cpo.policyRepoPath, "policy_repo_path", "./", "Path to the directory with a clean clone of github.com/slsa-framework/source-policies.")
 }
 
 func addCreatePolicy(parentCmd *cobra.Command) {
@@ -31,10 +31,10 @@ func addCreatePolicy(parentCmd *cobra.Command) {
 
 	createpolicyCmd := &cobra.Command{
 		Use:   "createpolicy",
-		Short: "Creates a policy in a local copy of slsa-source-poc",
-		Long: `Creates a SLSA source policy in a local copy of slsa-source-poc.
+		Short: "Creates a policy in a local copy of source-policies",
+		Long: `Creates a SLSA source policy in a local copy of source-policies.
 
-		The created policy should then be sent as a PR to slsa-framework/slsa-source-poc.`,
+		The created policy should then be sent as a PR to slsa-framework/source-policies.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -12,9 +12,9 @@ import (
 	"github.com/carabiner-dev/vcslocator"
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 type repoOptions struct {

--- a/internal/cmd/policy.go
+++ b/internal/cmd/policy.go
@@ -14,9 +14,9 @@ import (
 	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/release-utils/util"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 type policyViewOpts struct {

--- a/internal/cmd/prov.go
+++ b/internal/cmd/prov.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
 )
 
 type provOptions struct {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/auth"
 )
 
 var githubToken string

--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/util"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 type setupOpts struct {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -12,10 +12,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool"
 )
 
 var (

--- a/internal/cmd/verifycommit.go
+++ b/internal/cmd/verifycommit.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
 )
 
 type verifyCommitOptions struct {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"github.com/slsa-framework/slsa-source-poc/internal/cmd"
+	"github.com/slsa-framework/source-tool/internal/cmd"
 )
 
 func main() {

--- a/pkg/attest/provenance.go
+++ b/pkg/attest/provenance.go
@@ -19,9 +19,9 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
 )
 
 type ProvenanceAttestor struct {
@@ -141,7 +141,7 @@ func (pa ProvenanceAttestor) createCurrentProvenance(ctx context.Context, commit
 	// At the very least provenance is available starting now. :)
 	// ... indeed, but don't set the `since`` date because doing so breaks
 	// checking against policies.
-	// See https://github.com/slsa-framework/slsa-source-poc/issues/272
+	// See https://github.com/slsa-framework/source-tool/issues/272
 	curProvPred.AddControl(
 		&provenance.Control{
 			Name: slsa.ProvenanceAvailable.String(),
@@ -266,7 +266,7 @@ func (pa ProvenanceAttestor) CreateTagProvenance(ctx context.Context, commit, re
 
 	// Find the most recent VSA for this commit. Any reference is OK.
 	// TODO: in the future get all of them.
-	// TODO: we should actually verify this vsa: https://github.com/slsa-framework/slsa-source-poc/issues/148
+	// TODO: we should actually verify this vsa: https://github.com/slsa-framework/source-tool/issues/148
 	vsaStatement, vsaPred, err := GetVsa(ctx, pa.gh_connection, pa.verifier, commit, ghcontrol.AnyReference)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching VSA when creating tag provenance %w", err)

--- a/pkg/attest/provenance_test.go
+++ b/pkg/attest/provenance_test.go
@@ -14,10 +14,10 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/testsupport"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/testsupport"
 )
 
 var rulesetOldTime = time.Now().Add(-time.Hour)

--- a/pkg/attest/statement.go
+++ b/pkg/attest/statement.go
@@ -13,7 +13,7 @@ import (
 	spb "github.com/in-toto/attestation/go/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
 )
 
 type BundleReader struct {
@@ -37,7 +37,7 @@ func (br *BundleReader) convertLineToStatement(line string) (*spb.Statement, err
 	// Compatibility hack bridgind identities for repository migration
 	// See here for more info and when to drop:
 	//
-	//  https://github.com/slsa-framework/slsa-source-poc/issues/255
+	//  https://github.com/slsa-framework/source-tool/issues/255
 	if strings.Contains(err.Error(), "no matching CertificateIdentity") && strings.Contains(err.Error(), OldExpectedSan) {
 		ver, err := (&BndVerifier{
 			Options: VerificationOptions{

--- a/pkg/attest/verify.go
+++ b/pkg/attest/verify.go
@@ -25,7 +25,7 @@ const (
 	// this constant is part of a compatibility hack that should be reverted once the latests attestations
 	// of the repos are signed with the new identity.
 	//
-	// See https://github.com/slsa-framework/slsa-source-poc/issues/255
+	// See https://github.com/slsa-framework/source-tool/issues/255
 	OldExpectedSan = "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/heads/main"
 )
 

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -15,8 +15,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
 )
 
 const (

--- a/pkg/attest/vsa_test.go
+++ b/pkg/attest/vsa_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/google/go-github/v69/github"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/testsupport"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/testsupport"
 )
 
 func createTestVsa(t *testing.T, repoUri, ref, commit string, verifiedLevels slsa.SourceVerifiedLevels) string {

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -10,9 +10,9 @@ import (
 
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
 )
 
 type Auditor struct {

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/google/go-github/v69/github"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 const (

--- a/pkg/auth/authfakes/fake_authenticator_implementation.go
+++ b/pkg/auth/authfakes/fake_authenticator_implementation.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/auth"
 )
 
 type FakeAuthenticatorImplementation struct {

--- a/pkg/ghcontrol/checklevel.go
+++ b/pkg/ghcontrol/checklevel.go
@@ -13,9 +13,9 @@ import (
 	"github.com/google/go-github/v69/github"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 const (

--- a/pkg/ghcontrol/checklevel_test.go
+++ b/pkg/ghcontrol/checklevel_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-github/v69/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
 )
 
 var (

--- a/pkg/ghcontrol/git_types.go
+++ b/pkg/ghcontrol/git_types.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
 )
 
 // Matches any reference type.

--- a/pkg/ghcontrol/notes.go
+++ b/pkg/ghcontrol/notes.go
@@ -33,7 +33,7 @@ func (ghc *GitHubConnection) GetNotesForCommit(ctx context.Context, commit strin
 		// trying the sharded path above as notes will be found using this
 		// path only when there is a small number of notes in the repo.
 		//
-		// See  https://github.com/slsa-framework/slsa-source-poc/issues/215
+		// See  https://github.com/slsa-framework/source-tool/issues/215
 		contents, _, resp, err = ghc.Client().Repositories.GetContents(
 			ctx, ghc.Owner(), ghc.Repo(), commit,
 			&github.RepositoryContentGetOptions{Ref: "refs/notes/commits"},

--- a/pkg/ghcontrol/notes_test.go
+++ b/pkg/ghcontrol/notes_test.go
@@ -25,7 +25,7 @@ func TestGetNotesForCommit(t *testing.T) {
 		mustBeEmpty bool
 		mustErr     bool
 	}{
-		{name: "success", owner: "slsa-framework", repo: "slsa-source-poc", commit: "e573149ab3e574abc2e5a151a04acfaf2a59b453", mustBeEmpty: false, mustErr: false},
+		{name: "success", owner: "slsa-framework", repo: "source-tool", commit: "e573149ab3e574abc2e5a151a04acfaf2a59b453", mustBeEmpty: false, mustErr: false},
 		{name: "invalida-commit", owner: "kjsdhi373iuh", repo: "lksjdhfk3773", commit: "invalid", mustBeEmpty: true, mustErr: true},
 		{name: "non-existent", owner: "kjsdhi373iuh", repo: "lksjdhfk3773", commit: "de9395302d14b24c0a42685cf27315d93c88ff79", mustBeEmpty: true, mustErr: false},
 	} {

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -22,13 +22,13 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/backends/attestation/notes"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/backends/attestation/notes"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 const (

--- a/pkg/policy/policy.pb.go
+++ b/pkg/policy/policy.pb.go
@@ -313,8 +313,8 @@ const file_policy_proto_rawDesc = "" +
 	"\rproperty_name\x18\x01 \x01(\tR\fpropertyName\x120\n" +
 	"\x05since\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x05since\x12\x1d\n" +
 	"\n" +
-	"check_name\x18\x03 \x01(\tR\tcheckNameB\xdf\x02\n" +
-	"7com.in_toto_attestation.predicates.source_provenance.v1B\vPolicyProtoP\x01Z4github.com/slsa-framework/slsa-source-poc/pkg/policy\xa2\x02\x03IPS\xaa\x020InTotoAttestation.Predicates.SourceProvenance.V1\xca\x020InTotoAttestation\\Predicates\\SourceProvenance\\V1\xe2\x02<InTotoAttestation\\Predicates\\SourceProvenance\\V1\\GPBMetadata\xea\x023InTotoAttestation::Predicates::SourceProvenance::V1b\x06proto3"
+	"check_name\x18\x03 \x01(\tR\tcheckNameB\xdb\x02\n" +
+	"7com.in_toto_attestation.predicates.source_provenance.v1B\vPolicyProtoP\x01Z0github.com/slsa-framework/source-tool/pkg/policy\xa2\x02\x03IPS\xaa\x020InTotoAttestation.Predicates.SourceProvenance.V1\xca\x020InTotoAttestation\\Predicates\\SourceProvenance\\V1\xe2\x02<InTotoAttestation\\Predicates\\SourceProvenance\\V1\\GPBMetadata\xea\x023InTotoAttestation::Predicates::SourceProvenance::V1b\x06proto3"
 
 var (
 	file_policy_proto_rawDescOnce sync.Once

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -26,10 +26,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 const (

--- a/pkg/provenance/provenance.pb.go
+++ b/pkg/provenance/provenance.pb.go
@@ -345,8 +345,8 @@ const file_provenance_proto_rawDesc = "" +
 	"VsaSummary\x12\x1f\n" +
 	"\vsource_refs\x18\x01 \x03(\tR\n" +
 	"sourceRefs\x12'\n" +
-	"\x0fverified_levels\x18\x02 \x03(\tR\x0everifiedLevelsB\xe7\x02\n" +
-	"7com.in_toto_attestation.predicates.source_provenance.v1B\x0fProvenanceProtoP\x01Z8github.com/slsa-framework/slsa-source-poc/pkg/provenance\xa2\x02\x03IPS\xaa\x020InTotoAttestation.Predicates.SourceProvenance.V1\xca\x020InTotoAttestation\\Predicates\\SourceProvenance\\V1\xe2\x02<InTotoAttestation\\Predicates\\SourceProvenance\\V1\\GPBMetadata\xea\x023InTotoAttestation::Predicates::SourceProvenance::V1b\x06proto3"
+	"\x0fverified_levels\x18\x02 \x03(\tR\x0everifiedLevelsB\xe3\x02\n" +
+	"7com.in_toto_attestation.predicates.source_provenance.v1B\x0fProvenanceProtoP\x01Z4github.com/slsa-framework/source-tool/pkg/provenance\xa2\x02\x03IPS\xaa\x020InTotoAttestation.Predicates.SourceProvenance.V1\xca\x020InTotoAttestation\\Predicates\\SourceProvenance\\V1\xe2\x02<InTotoAttestation\\Predicates\\SourceProvenance\\V1\\GPBMetadata\xea\x023InTotoAttestation::Predicates::SourceProvenance::V1b\x06proto3"
 
 var (
 	file_provenance_proto_rawDescOnce sync.Once

--- a/pkg/repo/clone.go
+++ b/pkg/repo/clone.go
@@ -20,8 +20,8 @@ import (
 	"github.com/google/uuid"
 	"sigs.k8s.io/release-utils/command"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo/options"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/repo/options"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 // Clone is a local clone of a repository

--- a/pkg/repo/implementation.go
+++ b/pkg/repo/implementation.go
@@ -21,9 +21,9 @@ import (
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/google/go-github/v69/github"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo/options"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/repo/options"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 //counterfeiter:generate . prManagerImplementation

--- a/pkg/repo/pullrequest.go
+++ b/pkg/repo/pullrequest.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo/options"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/repo/options"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 func NewPullRequestManager(fn ...OptFn) *PullRequestManager {

--- a/pkg/repo/repofakes/fake_pr_manager_implementation.go
+++ b/pkg/repo/repofakes/fake_pr_manager_implementation.go
@@ -4,10 +4,10 @@ package repofakes
 import (
 	"sync"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo"
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo/options"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/repo"
+	"github.com/slsa-framework/source-tool/pkg/repo/options"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 type FakePrManagerImplementation struct {

--- a/pkg/slsa/slsa_types.go
+++ b/pkg/slsa/slsa_types.go
@@ -9,7 +9,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
 )
 
 type (

--- a/pkg/sourcetool/backends/attestation/notes/backend.go
+++ b/pkg/sourcetool/backends/attestation/notes/backend.go
@@ -12,11 +12,11 @@ import (
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	attestation "github.com/in-toto/attestation/go/v1"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 type Backend struct {

--- a/pkg/sourcetool/backends/vcs/github/github.go
+++ b/pkg/sourcetool/backends/vcs/github/github.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/attest"
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/ghcontrol"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/ghcontrol"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 func New() *Backend {

--- a/pkg/sourcetool/backends/vcs/github/manage.go
+++ b/pkg/sourcetool/backends/vcs/github/manage.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/google/go-github/v69/github"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo"
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo/options"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/repo"
+	"github.com/slsa-framework/source-tool/pkg/repo/options"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 const (
@@ -30,7 +30,7 @@ const (
 		`Every time a new commit merges to the specified branch, attestations will ` +
 		`be automatically signed and stored in git notes in this repository.` + "\n\n" +
 		`Note: This is an automated PR created using the ` +
-		`[SLSA sourcetool](https://github.com/slsa-framework/slsa-source-poc) utility.` + "\n"
+		`[SLSA sourcetool](https://github.com/slsa-framework/source-tool) utility.` + "\n"
 
 	workflowData = `---
 name: SLSA Source

--- a/pkg/sourcetool/implementation.go
+++ b/pkg/sourcetool/implementation.go
@@ -15,15 +15,15 @@ import (
 
 	"github.com/google/go-github/v69/github"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
-	"github.com/slsa-framework/slsa-source-poc/pkg/repo"
-	roptions "github.com/slsa-framework/slsa-source-poc/pkg/repo/options"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/backends/attestation/notes"
-	ghbackend "github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/backends/vcs/github"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/options"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/repo"
+	roptions "github.com/slsa-framework/source-tool/pkg/repo/options"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/backends/attestation/notes"
+	ghbackend "github.com/slsa-framework/source-tool/pkg/sourcetool/backends/vcs/github"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/options"
 )
 
 // toolImplementation defines the mockable implementation of source tool

--- a/pkg/sourcetool/models/models.go
+++ b/pkg/sourcetool/models/models.go
@@ -14,8 +14,8 @@ import (
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	attestation "github.com/in-toto/attestation/go/v1"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
 )
 
 var ErrProtectionAlreadyInPlace = errors.New("controls already in place in the repository")

--- a/pkg/sourcetool/models/modelsfakes/fake_attestation_storage_reader.go
+++ b/pkg/sourcetool/models/modelsfakes/fake_attestation_storage_reader.go
@@ -7,8 +7,8 @@ import (
 
 	v1a "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	v1 "github.com/in-toto/attestation/go/v1"
-	"github.com/slsa-framework/slsa-source-poc/pkg/provenance"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/provenance"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 type FakeAttestationStorageReader struct {

--- a/pkg/sourcetool/models/modelsfakes/fake_vcs_backend.go
+++ b/pkg/sourcetool/models/modelsfakes/fake_vcs_backend.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 type FakeVcsBackend struct {

--- a/pkg/sourcetool/options.go
+++ b/pkg/sourcetool/options.go
@@ -6,7 +6,7 @@ package sourcetool
 import (
 	"errors"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/auth"
 )
 
 type ConfigFn func(*Tool) error

--- a/pkg/sourcetool/options/options.go
+++ b/pkg/sourcetool/options/options.go
@@ -6,7 +6,7 @@ package options
 import (
 	"fmt"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/policy"
 )
 
 type Options struct {

--- a/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
+++ b/pkg/sourcetool/sourcetoolfakes/fake_tool_implementation.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"sync"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/options"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/options"
 )
 
 type FakeToolImplementation struct {

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -15,11 +15,11 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/auth"
-	"github.com/slsa-framework/slsa-source-poc/pkg/policy"
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/options"
+	"github.com/slsa-framework/source-tool/pkg/auth"
+	"github.com/slsa-framework/source-tool/pkg/policy"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/options"
 )
 
 var ControlConfigurations = []models.ControlConfiguration{

--- a/pkg/sourcetool/tool_test.go
+++ b/pkg/sourcetool/tool_test.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/slsa-framework/slsa-source-poc/pkg/slsa"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/models/modelsfakes"
-	"github.com/slsa-framework/slsa-source-poc/pkg/sourcetool/sourcetoolfakes"
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models/modelsfakes"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/sourcetoolfakes"
 )
 
 func TestGetBranchControls(t *testing.T) {
@@ -166,7 +166,7 @@ func TestFindPolicyPR(t *testing.T) {
 			"pr-is-found", false, &models.PullRequest{
 				Repo: &models.Repository{
 					Hostname:      "github.com",
-					Path:          "slsa-framework/slsa-source-poc",
+					Path:          "slsa-framework/source-tool",
 					DefaultBranch: "",
 				},
 				Number: 10,
@@ -178,7 +178,7 @@ func TestFindPolicyPR(t *testing.T) {
 				i.SearchPullRequestReturns(&models.PullRequest{
 					Repo: &models.Repository{
 						Hostname:      "github.com",
-						Path:          "slsa-framework/slsa-source-poc",
+						Path:          "slsa-framework/source-tool",
 						DefaultBranch: "",
 					},
 					Number: 10,

--- a/proto/v1/policy.proto
+++ b/proto/v1/policy.proto
@@ -7,7 +7,7 @@ package in_toto_attestation.predicates.source_provenance.v1;
 import "google/protobuf/timestamp.proto";
 
 // buf:lint:ignore PACKAGE_SAME_GO_PACKAGE
-option go_package = "github.com/slsa-framework/slsa-source-poc/pkg/policy";
+option go_package = "github.com/slsa-framework/source-tool/pkg/policy";
 
 // The repository policy definition
 message RepoPolicy {

--- a/proto/v1/provenance.proto
+++ b/proto/v1/provenance.proto
@@ -7,7 +7,7 @@ package in_toto_attestation.predicates.source_provenance.v1;
 import "google/protobuf/timestamp.proto";
 
 // buf:lint:ignore PACKAGE_SAME_GO_PACKAGE
-option go_package = "github.com/slsa-framework/slsa-source-poc/pkg/provenance";
+option go_package = "github.com/slsa-framework/source-tool/pkg/provenance";
 
 // The predicate that encodes source provenance data.
 // The git commit this corresponds to is encoded in the surrounding statement.


### PR DESCRIPTION
This PR updates import paths, names and URIs across the code base following up the recent repository rename from `slsa-source-poc` to `source-tool`. This PR has the tasks required to migrate everything to the new name (except the items listed below):

### Migration tasks:

This PR updates the following

- Main module renamed
- Linter configuration
- Import paths in all Go files
- Package names in protocol buffers definitions
- URLs in docs* (see below)

### Not updated:

The follow locations have not been changed:

- Main README and GETTING_STARTED docs (new version is coming after the pilot program)
- URLs in provenance predicate types
- Old workflows we are deprecating for new ones in [slsa-framework/source-actions](https://github.com/slsa-framework/source-actions)
- URLs in the policy directory, being deprecated for those in [slsa-framework/source-policies](https://github.com/slsa-framework/source-policies) (see #282 and #283)

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>
