### PR TITLE
Define default user and email on PRs

### DIFF
--- a/pkg/sourcetool/backends/vcs/github/manage.go
+++ b/pkg/sourcetool/backends/vcs/github/manage.go
@@ -82,6 +82,11 @@ func (b *Backend) CreateWorkflowPR(r *models.Repository, branches []*models.Bran
 		return nil, errors.New("no branches specified")
 	}
 
+	user, err := b.authenticator.WhoAmI()
+	if err != nil {
+		return nil, err
+	}
+
 	// Populate the branches in the workflow template
 	quotedBranchesList := []string{}
 	for _, b := range branches {
@@ -112,6 +117,10 @@ func (b *Backend) CreateWorkflowPR(r *models.Repository, branches []*models.Bran
 		&options.PullRequestFileListOptions{
 			Title: workflowCommitMessage,
 			Body:  workflowPRBody,
+			CommitOptions: options.CommitOptions{
+				Name:  user.GetLogin(),
+				Email: user.GetLogin() + "@users.noreply.github.com",
+			},
 		},
 		[]*repo.PullRequestFileEntry{
 			{

--- a/pkg/sourcetool/implementation.go
+++ b/pkg/sourcetool/implementation.go
@@ -90,6 +90,11 @@ func (impl *defaultToolImplementation) CreatePolicyPR(a *auth.Authenticator, opt
 	if p == nil {
 		return nil, fmt.Errorf("policy is nil")
 	}
+	user, err := a.WhoAmI()
+	if err != nil {
+		return nil, err
+	}
+
 	repoOwner, repoName, err := r.PathAsGitHubOwnerName()
 	if err != nil {
 		return nil, err
@@ -134,6 +139,10 @@ func (impl *defaultToolImplementation) CreatePolicyPR(a *auth.Authenticator, opt
 		&roptions.PullRequestFileListOptions{
 			Title: fmt.Sprintf("Add %s/%s SLSA Source policy file", repoOwner, repoName),
 			Body:  fmt.Sprintf(`This pull request adds the SLSA source policy for github.com/%s/%s`, repoOwner, repoName),
+			CommitOptions: roptions.CommitOptions{
+				Name:  user.GetLogin(),
+				Email: user.GetLogin() + "@users.noreply.github.com",
+			},
 		},
 		[]*repo.PullRequestFileEntry{
 			{


### PR DESCRIPTION
This commit modifies the PR calls to initialize them with a default user and email based on the auth token.

Closes #289