### PR TITLE
Handle missing permissions more gracefully

### DIFF
--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -448,6 +448,14 @@ a fork of the repository you want to protect.
 					fmt.Printf("\n   ℹ️  Controls already enabled on %s\n\n", opts.GetRepository().Path)
 					return nil
 				}
+
+				if errors.Is(err, models.ErrRepositoryAccessDenied) {
+					fmt.Printf("\n   🔐 %s sourcetool does not have access to %s\n\n", colorHiRed("Error:"), opts.GetRepository().Path)
+					fmt.Println()
+					fmt.Printf("Please run %s again and grant the app access\n", w("sourcetool auth login"))
+					fmt.Println("to the repository or organization.")
+					return nil
+				}
 				return fmt.Errorf("configuring controls: %w", err)
 			}
 

--- a/pkg/sourcetool/models/models.go
+++ b/pkg/sourcetool/models/models.go
@@ -18,7 +18,10 @@ import (
 	"github.com/slsa-framework/source-tool/pkg/slsa"
 )
 
-var ErrProtectionAlreadyInPlace = errors.New("controls already in place in the repository")
+var (
+	ErrProtectionAlreadyInPlace = errors.New("controls already in place in the repository")
+	ErrRepositoryAccessDenied   = errors.New("access to repository denied")
+)
 
 // AttestationStorageReader abstracts an attestation storage system where
 // sourcetool can read VSAs and provenance attestations.


### PR DESCRIPTION
This PR makes sourcetool returns meaningful errors when the token is missing access to update repositories to provide more helpful guidance to users.

<img width="603" height="169" alt="image" src="https://github.com/user-attachments/assets/e4bca3fc-4cab-4527-a6c6-273b2ad620ed" />


Fixes: https://github.com/slsa-framework/source-tool/issues/288