### PR TITLE
CI: Standarize rading go version from go.mod

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Setup Buf

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 'stable'
+          go-version-file: go.mod
           cache: false
 
       - run: |


### PR DESCRIPTION
This PR standardizes the way we pick the go version in CI across all workflows to fix a version skew problem that arose with the release of go 1.25