### PR TITLE
Honor custom signer identities during chain evaluation

### DIFF
--- a/pkg/sourcetool/backends/vcs/github/github.go
+++ b/pkg/sourcetool/backends/vcs/github/github.go
@@ -66,11 +66,28 @@ var InherentControls = slsa.ControlNameSet{
 	// slsa.SLSA_SOURCE_SCS_TWO_PARTY_REVIEW,
 }
 
-func New(options *models.BackendOptions) *Backend {
-	return &Backend{
+// Option configures a GitHub backend.
+type Option func(*Backend)
+
+// WithVerifier configures the verifier used when reading prior attestations.
+func WithVerifier(verifier attest.Verifier) Option {
+	return func(backend *Backend) {
+		if verifier != nil {
+			backend.verifier = verifier
+		}
+	}
+}
+
+func New(options *models.BackendOptions, opts ...Option) *Backend {
+	backend := &Backend{
 		authenticator: auth.New(),
 		Options:       options,
+		verifier:      attest.GetDefaultVerifier(),
 	}
+	for _, opt := range opts {
+		opt(backend)
+	}
+	return backend
 }
 
 type Options struct {
@@ -81,6 +98,7 @@ type Options struct {
 type Backend struct {
 	authenticator *auth.Authenticator
 	Options       *models.BackendOptions
+	verifier      attest.Verifier
 }
 
 // getGitHubConnection builds a github connector to a repository
@@ -152,7 +170,7 @@ func (b *Backend) GetBranchControlsAtCommit(ctx context.Context, branch *models.
 	// We need to manually check for PROVENANCE_AVAILABLE which is not
 	// handled by ghcontrol
 	attester, err := attest.NewAttester(
-		attest.WithBackend(b), attest.WithVerifier(attest.GetDefaultVerifier()),
+		attest.WithBackend(b), attest.WithVerifier(b.verifier),
 		attest.WithAuthenticator(b.authenticator),
 	)
 	if err != nil {

--- a/pkg/sourcetool/backends/vcs/github/github_test.go
+++ b/pkg/sourcetool/backends/vcs/github/github_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright 2026 The SLSA Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/slsa-framework/source-tool/pkg/attest"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+)
+
+func TestNewUsesDefaultVerifier(t *testing.T) {
+	t.Parallel()
+
+	backend := New(&models.BackendOptions{})
+	verifier, ok := backend.verifier.(*attest.BndVerifier)
+
+	require.True(t, ok)
+	require.Equal(t, attest.DefaultVerifierOptions, verifier.Options)
+}
+
+func TestNewUsesConfiguredVerifier(t *testing.T) {
+	t.Parallel()
+
+	verifier := attest.NewBndVerifier(attest.VerificationOptions{
+		ExpectedIssuer: "https://token.actions.githubusercontent.com",
+		ExpectedSan:    "https://github.com/acme/project/.github/workflows/provenance.yml@refs/heads/main",
+	})
+
+	backend := New(&models.BackendOptions{}, WithVerifier(verifier))
+
+	require.Same(t, verifier, backend.verifier)
+}
+
+func TestWithVerifierIgnoresNil(t *testing.T) {
+	t.Parallel()
+
+	backend := New(&models.BackendOptions{}, WithVerifier(nil))
+
+	require.NotNil(t, backend.verifier)
+}

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -52,8 +52,6 @@ func New(funcs ...ConfigFn) (*Tool, error) {
 		}
 	}
 
-	t.backend = github.New(&t.Options.BackendOptions)
-
 	// Build the attestation verifier, honoring any identity overrides
 	verifierOptions := attest.DefaultVerifierOptions
 	if t.Options.ExpectedIssuer != "" {
@@ -65,10 +63,16 @@ func New(funcs ...ConfigFn) (*Tool, error) {
 		verifierOptions.ExpectedSan = t.Options.ExpectedSan
 		verifierOptions.AlternateSans = nil
 	}
+	verifier := attest.NewBndVerifier(verifierOptions)
+
+	t.backend = github.New(
+		&t.Options.BackendOptions,
+		github.WithVerifier(verifier),
+	)
 
 	// Create the tool's attester
 	attester, err := attest.NewAttester(
-		attest.WithVerifier(attest.NewBndVerifier(verifierOptions)),
+		attest.WithVerifier(verifier),
 		attest.WithBackend(t.backend),
 		attest.WithGithubCollector(t.Options.InitGHCollector),
 		attest.WithNotesCollector(t.Options.InitNotesCollector),


### PR DESCRIPTION
Closes #436.

## Summary

- Reuse the attestation verifier configured by `--expected-issuer` and `--expected-san` when the GitHub backend evaluates prior attestations.
- Preserve the default SLSA workflow identity for callers that construct the backend without a verifier override.
- Add regression coverage for default, custom, and nil verifier configuration.

## Problem

`sourcetool.New` already creates a verifier from the configured expected identity for its top-level attester. However, `Backend.GetBranchControlsAtCommit` creates another attester with `attest.GetDefaultVerifier()`.

That second verifier rejects otherwise valid prior attestations signed by a caller's configured workflow identity. As a result, provenance and VSA controls do not carry forward during chain evaluation, and the computed SLSA Source level can remain at L1.

## Implementation

The GitHub backend constructor now accepts optional backend configuration while retaining its existing default behavior. `sourcetool.New` builds one verifier and passes it to both the top-level attester and the GitHub backend. Chain evaluation therefore uses the same issuer, SAN, and alternate-SAN policy as direct attestation verification.

This does not broaden trust by default. Existing `github.New(options)` callers still receive `attest.GetDefaultVerifier()`, and a nil verifier option leaves that default intact.

## Validation

- `go test ./...`
- `go test -race -count=1 ./pkg/sourcetool/... ./pkg/attest/...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0 run ./...`
- `git diff --check`
