### PR TITLE
Point workflow automation at slsa-framework/actions and pin to latest release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/sigstore/sigstore-go v1.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.12.1
+	golang.org/x/mod v0.38.0
 	google.golang.org/protobuf v1.36.12
 	sigs.k8s.io/release-utils v0.12.4
 )
@@ -155,7 +156,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/pkg/sourcetool/backends/vcs/github/manage.go
+++ b/pkg/sourcetool/backends/vcs/github/manage.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v88/github"
+	"golang.org/x/mod/semver"
 
 	"github.com/slsa-framework/source-tool/pkg/repo"
 	"github.com/slsa-framework/source-tool/pkg/repo/options"
@@ -18,10 +19,11 @@ import (
 )
 
 const (
+	// ActionsOrg and ActionsRepo point to the repository hosting the reusable
+	// provenance workflow the generated workflow calls.
 	ActionsOrg   = "slsa-framework"
-	ActionsRepo  = "source-actions"
+	ActionsRepo  = "actions"
 	workflowPath = ".github/workflows/compute_slsa_source.yaml"
-	// workflowSource = "git+https://github.com/slsa-"
 
 	// githubActionsBotLogin and githubActionsBotEmail are the login and email
 	// GitHub uses for the actions bot. It is not a regular noreply.github.com
@@ -56,6 +58,9 @@ jobs:
     uses: %s/%s/.github/workflows/compute_slsa_source.yml@%s # %s
 
 `
+
+	// actionsTagsPerPage is the page size used when listing the actions repo tags
+	actionsTagsPerPage = 100
 )
 
 // checkPushAccess
@@ -100,15 +105,7 @@ func (b *Backend) CreateWorkflowPR(r *models.Repository, branches []*models.Bran
 		return nil, fmt.Errorf("getting latest actions tag: %w", err)
 	}
 
-	// Populate the branches in the workflow template
-	quotedBranchesList := []string{}
-	for _, b := range branches {
-		quotedBranchesList = append(quotedBranchesList, fmt.Sprintf("%q", b.Name))
-	}
-	workflowYAML := fmt.Sprintf(
-		workflowData, strings.Join(quotedBranchesList, ", "),
-		ActionsOrg, ActionsRepo, actionsHash, actionsTag,
-	)
+	workflowYAML := buildWorkflowYAML(branches, actionsTag, actionsHash)
 
 	// We need to determine if the user needs a fork
 	hasPush, err := b.checkPushAccess(r)
@@ -151,6 +148,21 @@ func (b *Backend) CreateWorkflowPR(r *models.Repository, branches []*models.Bran
 
 	// Success!
 	return pr, nil
+}
+
+// buildWorkflowYAML renders the provenance workflow that will be added to the
+// repository. The reusable workflow is pinned to the commit digest of the
+// actions repository tag, while the tag name is added as a comment so that
+// dependabot can keep the pin updated.
+func buildWorkflowYAML(branches []*models.Branch, actionsTag, actionsDigest string) string {
+	quotedBranchesList := make([]string, 0, len(branches))
+	for _, b := range branches {
+		quotedBranchesList = append(quotedBranchesList, fmt.Sprintf("%q", b.Name))
+	}
+	return fmt.Sprintf(
+		workflowData, strings.Join(quotedBranchesList, ", "),
+		ActionsOrg, ActionsRepo, actionsDigest, actionsTag,
+	)
 }
 
 // commitEmailForActor returns the no-reply email address to use when authoring
@@ -378,33 +390,60 @@ func (b *Backend) ConfigureControls(r *models.Repository, branches []*models.Bra
 	return errors.Join(errs...)
 }
 
-// GetLatestActionsTag queries GitHub and fetches the latest tag and digest
-// of the slsa-framework/source-actions repository.
+// GetLatestActionsTag queries GitHub and returns the name and commit digest
+// of the latest release tag of the actions repository (ActionsOrg/ActionsRepo).
 func (b *Backend) GetLatestActionsTag() (tag, digest string, err error) {
 	client, err := b.authenticator.GetGitHubClient()
 	if err != nil {
 		return "", "", fmt.Errorf("getting GitHub client: %w", err)
 	}
 
-	// List tags from slsa-framework/source-actions
-	tags, _, err := client.Repositories.ListTags(
-		context.Background(), ActionsOrg, ActionsRepo,
-		&github.ListOptions{
-			Page:    1,
-			PerPage: 1,
-		},
-	)
-	if err != nil {
-		return "", "", fmt.Errorf("listing tags: %w", err)
+	return latestActionsTag(context.Background(), client)
+}
+
+// latestActionsTag lists all the tags of the actions repository and returns
+// the name and commit digest of the tag with the highest release version.
+func latestActionsTag(ctx context.Context, client *github.Client) (tag, digest string, err error) {
+	tags := []*github.RepositoryTag{}
+	opts := &github.ListOptions{PerPage: actionsTagsPerPage}
+	for {
+		page, resp, listErr := client.Repositories.ListTags(ctx, ActionsOrg, ActionsRepo, opts)
+		if listErr != nil {
+			return "", "", fmt.Errorf("listing tags of %s/%s: %w", ActionsOrg, ActionsRepo, listErr)
+		}
+		tags = append(tags, page...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 
-	if len(tags) == 0 {
-		return "", "", errors.New("no tags found in slsa-framework/source-actions")
+	latest := latestReleaseTag(tags)
+	if latest == nil {
+		return "", "", fmt.Errorf("no release tags found in %s/%s", ActionsOrg, ActionsRepo)
 	}
 
-	latestTag := tags[0]
-	tagName := latestTag.GetName()
-	commitSHA := latestTag.GetCommit().GetSHA()
+	if latest.GetCommit().GetSHA() == "" {
+		return "", "", fmt.Errorf("tag %s of %s/%s has no commit digest", latest.GetName(), ActionsOrg, ActionsRepo)
+	}
 
-	return tagName, commitSHA, nil
+	return latest.GetName(), latest.GetCommit().GetSHA(), nil
+}
+
+// latestReleaseTag returns the tag with the highest release version. Only tags
+// named as full semantic versions (vMAJOR.MINOR.PATCH) are considered, so
+// prereleases, floating tags (eg v1) and tags not following the semver format
+// are ignored. Returns nil when the list has no release tags.
+func latestReleaseTag(tags []*github.RepositoryTag) *github.RepositoryTag {
+	var latest *github.RepositoryTag
+	for _, t := range tags {
+		name := t.GetName()
+		if !semver.IsValid(name) || semver.Canonical(name) != name || semver.Prerelease(name) != "" {
+			continue
+		}
+		if latest == nil || semver.Compare(name, latest.GetName()) > 0 {
+			latest = t
+		}
+	}
+	return latest
 }

--- a/pkg/sourcetool/backends/vcs/github/manage_test.go
+++ b/pkg/sourcetool/backends/vcs/github/manage_test.go
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright 2026 The SLSA Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+)
+
+func testTag(name, sha string) *github.RepositoryTag {
+	return &github.RepositoryTag{
+		Name:   github.Ptr(name),
+		Commit: &github.Commit{SHA: github.Ptr(sha)},
+	}
+}
+
+func TestBuildWorkflowYAML(t *testing.T) {
+	t.Parallel()
+	yaml := buildWorkflowYAML(
+		[]*models.Branch{{Name: "main"}, {Name: "release-1.0"}},
+		"v0.1.0", "dea965cdca5e0cb422bf7b2653c9d15f678ad01c",
+	)
+
+	assert.Contains(t, yaml, `branches: [ "main", "release-1.0" ]`)
+	assert.Contains(
+		t, yaml,
+		"uses: slsa-framework/actions/.github/workflows/compute_slsa_source.yml@dea965cdca5e0cb422bf7b2653c9d15f678ad01c # v0.1.0",
+	)
+	assert.NotContains(t, yaml, "@main")
+}
+
+func TestLatestReleaseTag(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		tags   []*github.RepositoryTag
+		expect string
+	}{
+		{"empty", nil, ""},
+		{"single", []*github.RepositoryTag{testTag("v0.1.0", "a")}, "v0.1.0"},
+		{
+			// Sorting must be numeric, not lexicographic
+			"numeric-order",
+			[]*github.RepositoryTag{
+				testTag("v0.9.0", "a"), testTag("v0.10.0", "b"), testTag("v0.1.0", "c"),
+			},
+			"v0.10.0",
+		},
+		{
+			"skip-prereleases",
+			[]*github.RepositoryTag{testTag("v0.1.0", "a"), testTag("v0.2.0-rc.1", "b")},
+			"v0.1.0",
+		},
+		{
+			"skip-floating-tags",
+			[]*github.RepositoryTag{testTag("v1", "a"), testTag("v1.0", "b"), testTag("v0.5.0", "c")},
+			"v0.5.0",
+		},
+		{
+			"skip-non-semver",
+			[]*github.RepositoryTag{
+				testTag("latest", "a"), testTag("1.2.3", "b"), testTag("v0.3.0", "c"), testTag("", "d"),
+			},
+			"v0.3.0",
+		},
+		{"only-prereleases", []*github.RepositoryTag{testTag("v1.0.0-alpha", "a")}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			latest := latestReleaseTag(tc.tags)
+			if tc.expect == "" {
+				assert.Nil(t, latest)
+				return
+			}
+			require.NotNil(t, latest)
+			assert.Equal(t, tc.expect, latest.GetName())
+		})
+	}
+}
+
+func TestLatestActionsTag(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name         string
+		mockOption   mock.MockBackendOption
+		expectTag    string
+		expectDigest string
+		mustErr      bool
+	}{
+		{
+			// The latest tag lives in the second page, ensuring all pages are read
+			name: "paginated",
+			mockOption: mock.WithRequestMatchPages(
+				mock.GetReposTagsByOwnerByRepo,
+				[]*github.RepositoryTag{testTag("v0.1.0", "aaa"), testTag("v0.2.0-rc.1", "bbb")},
+				[]*github.RepositoryTag{testTag("v0.1.1", "ccc"), testTag("v1", "ddd")},
+			),
+			expectTag:    "v0.1.1",
+			expectDigest: "ccc",
+		},
+		{
+			name: "no-release-tags",
+			mockOption: mock.WithRequestMatch(
+				mock.GetReposTagsByOwnerByRepo,
+				[]*github.RepositoryTag{testTag("main", "aaa"), testTag("v1.0.0-rc.1", "bbb")},
+			),
+			mustErr: true,
+		},
+		{
+			name:       "no-tags",
+			mockOption: mock.WithRequestMatch(mock.GetReposTagsByOwnerByRepo, []*github.RepositoryTag{}),
+			mustErr:    true,
+		},
+		{
+			name: "missing-digest",
+			mockOption: mock.WithRequestMatch(
+				mock.GetReposTagsByOwnerByRepo,
+				[]*github.RepositoryTag{{Name: github.Ptr("v0.1.0")}},
+			),
+			mustErr: true,
+		},
+		{
+			name: "api-error",
+			mockOption: mock.WithRequestMatchHandler(
+				mock.GetReposTagsByOwnerByRepo,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					mock.WriteError(w, http.StatusInternalServerError, "boom")
+				}),
+			),
+			mustErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, err := github.NewClient(github.WithHTTPClient(mock.NewMockedHTTPClient(tc.mockOption)))
+			require.NoError(t, err)
+
+			tag, digest, err := latestActionsTag(t.Context(), client)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectTag, tag)
+			assert.Equal(t, tc.expectDigest, digest)
+		})
+	}
+}


### PR DESCRIPTION
This PR updates the workflow automation in sourcetool to write the workflows in user's repos pointing to the new SLSA actions repo (slsa-framework/actions).

In addition, sourcetool now fetches the tags and creates the workflow pointing to the latest tagged release.