### PR TITLE
Add support to migrate to new actions repo

### DIFF
--- a/internal/cmd/setup.go
+++ b/internal/cmd/setup.go
@@ -294,7 +294,8 @@ this is required to reach SLSA source level 2+.
 
 %s
 Opens a pull request in the repository to add the provenance generation workflow
-after every push. 
+after every push. If the repository already has a workflow calling the SLSA
+actions from a deprecated location, the pull request updates it instead.
 
 %s
 Opens a pull request on the SLSA policy repository to check in a SLSA Source 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -16,6 +16,7 @@ import (
 	"github.com/slsa-framework/source-tool/pkg/policy"
 	"github.com/slsa-framework/source-tool/pkg/slsa"
 	"github.com/slsa-framework/source-tool/pkg/sourcetool"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
 )
 
 var (
@@ -137,6 +138,12 @@ sourcetool status myorg/myrepo@mybranch
 				return nil
 			}
 
+			// Look for provenance workflows that need to be updated
+			workflows, err := srctool.FindProvenanceWorkflows(cmd.Context(), opts.GetBranch())
+			if err != nil {
+				return fmt.Errorf("checking provenance workflows: %w", err)
+			}
+
 			title := fmt.Sprintf(
 				"\nSLSA Source Status for %s/%s@%s", opts.owner, opts.repository,
 				ghcontrol.BranchToFullRef(opts.branch),
@@ -197,8 +204,11 @@ sourcetool status myorg/myrepo@mybranch
 
 			fmt.Println(w("Current SLSA Source level: " + verifiedLevel))
 			printLevelGap(toplevel, verifiedLevel, evalResult.Shortfall)
+			printLegacyWorkflows(workflows)
 			fmt.Println("")
-			titled := false
+
+			// Collect the recommended actions from the controls
+			actions := []*slsa.ControlRecommendedAction{}
 			for _, status := range controls.Controls {
 				if status.RecommendedAction == nil {
 					continue
@@ -208,28 +218,25 @@ sourcetool status myorg/myrepo@mybranch
 				if status.Name == slsa.PolicyAvailable && !slsa.IsLevelHigherOrEqualTo(toplevel, slsa.SlsaSourceLevel3) {
 					continue
 				}
-
-				if !titled {
-					fmt.Println(w2("✨ Recommended actions:"))
-					titled = true
-				}
-
-				fmt.Printf(" - %s\n", status.RecommendedAction.Message)
-				if status.RecommendedAction.Command != "" {
-					fmt.Printf("   > %s\n", status.RecommendedAction.Command)
-				}
-				fmt.Println()
+				actions = append(actions, status.RecommendedAction)
 			}
 
+			// ... from the provenance workflows
+			for _, wf := range workflows {
+				if wf.RecommendedAction != nil {
+					actions = append(actions, wf.RecommendedAction)
+				}
+			}
+
+			// ... and from the policy
 			if policyNeedsUpdate {
-				if !titled {
-					fmt.Println(w2("✨ Recommended actions:"))
-				}
-				fmt.Println(" - Update the repository source policy")
-				fmt.Printf("   > sourcetool policy create --update %s\n", opts.GetRepository().Path)
-				fmt.Println()
+				actions = append(actions, &slsa.ControlRecommendedAction{
+					Message: "Update the repository source policy",
+					Command: "sourcetool policy create --update " + opts.GetRepository().Path,
+				})
 			}
 
+			printRecommendedActions(actions)
 			return nil
 		},
 	}
@@ -246,6 +253,35 @@ func firstSourceLevel(levels slsa.SourceVerifiedLevels) string {
 		}
 	}
 	return string(slsa.SlsaSourceLevel0)
+}
+
+// printRecommendedActions prints the list of recommended actions, if any
+func printRecommendedActions(actions []*slsa.ControlRecommendedAction) {
+	if len(actions) == 0 {
+		return
+	}
+	fmt.Println(w2("✨ Recommended actions:"))
+	for _, action := range actions {
+		fmt.Printf(" - %s\n", action.Message)
+		if action.Command != "" {
+			fmt.Printf("   > %s\n", action.Command)
+		}
+		fmt.Println()
+	}
+}
+
+// printLegacyWorkflows warns about provenance workflows still calling the
+// SLSA actions from a deprecated repository.
+func printLegacyWorkflows(workflows []*models.ProvenanceWorkflow) {
+	for _, wf := range workflows {
+		if !wf.IsLegacy() {
+			continue
+		}
+		fmt.Printf(
+			"%s The workflow %s calls the SLSA actions from the deprecated %s repository.\n",
+			w2("⚠️ "), wf.Path, strings.Join(wf.LegacyActionsRepos, " and "),
+		)
+	}
 }
 
 // printLevelGap explains when the policy-verified level is below the level the

--- a/pkg/attest/provenance.go
+++ b/pkg/attest/provenance.go
@@ -207,9 +207,9 @@ func (a *Attester) GetRevisionVSA(ctx context.Context, branch *models.Branch, re
 			continue
 		}
 
-		// Check the verifier ID matches
-		if vsaPred.GetVerifier().GetId() != VsaVerifierId {
-			Debugf("VSA verfier ID does not match %s", VsaVerifierId)
+		// Check the verifier ID is one we accept
+		if !IsAcceptedVsaVerifierId(vsaPred.GetVerifier().GetId()) {
+			Debugf("VSA verifier ID %q is not one of %v", vsaPred.GetVerifier().GetId(), AcceptedVsaVerifierIds)
 			continue
 		}
 

--- a/pkg/attest/verify.go
+++ b/pkg/attest/verify.go
@@ -6,6 +6,7 @@ package attest
 import (
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/carabiner-dev/attestation"
 	"github.com/carabiner-dev/signer"
@@ -15,12 +16,23 @@ import (
 )
 
 type VerificationOptions struct {
+	// ExpectedIssuer is the OIDC issuer of the certificates signing the
+	// attestations. It is required, no identity is accepted without it.
 	ExpectedIssuer string
-	ExpectedSan    string
 
-	// AlternateSans lists additional signer identities accepted when
-	// verifying attestations. It carries the pre-rename workflow identity
-	// while repositories still have attestations signed with it.
+	// ExpectedSan pins the signer identity to an exact subject alternative
+	// name. When set, ExpectedSanPrefix is ignored.
+	ExpectedSan string
+
+	// ExpectedSanPrefix accepts any signer identity starting with the
+	// prefix. Users pin the provenance workflow to different tags and
+	// digests, so the git reference ending its identity varies.
+	ExpectedSanPrefix string
+
+	// AlternateSans lists additional signer identities accepted (exactly)
+	// when verifying attestations. It carries the identities of the
+	// workflows that signed attestations before the actions moved to their
+	// current repository.
 	//
 	// See https://github.com/slsa-framework/source-tool/issues/255
 	AlternateSans []string
@@ -30,24 +42,88 @@ const (
 	// ExpectedIssuer is the OIDC issuer found in the sigstore bundles
 	ExpectedIssuer = "https://token.actions.githubusercontent.com"
 
-	// Expected SAN is the expected identity of the workflow signing the
-	// provenance and VSAs.
-	ExpectedSan = "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/main"
+	// ExpectedSanPrefix is the prefix of the identity of the reusable workflow
+	// signing the provenance and VSAs. The full identity ends with the git
+	// reference the workflow was pinned to, which varies across users and
+	// releases.
+	ExpectedSanPrefix = "https://github.com/slsa-framework/actions/.github/workflows/compute_slsa_source.yml@"
 
-	// OldExpectedSan is the old singer identity before splitting out the actions to their own repo
-	// this constant is part of a compatibility hack that should be reverted once the latests attestations
-	// of the repos are signed with the new identity.
+	// LegacySourceActionsSan is the identity of the workflow that signed
+	// attestations while the actions lived in slsa-framework/source-actions.
+	LegacySourceActionsSan = "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/main"
+
+	// LegacyPocSan is the identity of the workflow that signed attestations
+	// before the actions were split out of the slsa-source-poc repository.
 	//
 	// See https://github.com/slsa-framework/source-tool/issues/255
-	OldExpectedSan = "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/heads/main"
+	LegacyPocSan = "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/heads/main"
 )
 
-// TODO: Update ExpectedSan to support regex so we can get the branches/tags we really think
-// folks should be using (they won't all run from main).
+// DefaultVerifierOptions accept attestations signed by the current provenance
+// workflow, whatever reference it is pinned to, and by the legacy workflows
+// while repositories still carry attestations signed by them.
 var DefaultVerifierOptions = VerificationOptions{
-	ExpectedIssuer: ExpectedIssuer,
-	ExpectedSan:    ExpectedSan,
-	AlternateSans:  []string{OldExpectedSan},
+	ExpectedIssuer:    ExpectedIssuer,
+	ExpectedSanPrefix: ExpectedSanPrefix,
+	AlternateSans:     []string{LegacySourceActionsSan, LegacyPocSan},
+}
+
+// expectedIdentities returns the signer identities accepted by the options.
+// Without an issuer no identity is accepted.
+func (vo *VerificationOptions) expectedIdentities() []*sapi.Identity {
+	if vo.ExpectedIssuer == "" {
+		return nil
+	}
+
+	ids := []*sapi.Identity{}
+	switch {
+	case vo.ExpectedSan != "":
+		ids = append(ids, exactIdentity(vo.ExpectedIssuer, vo.ExpectedSan))
+	case vo.ExpectedSanPrefix != "":
+		ids = append(ids, &sapi.Identity{
+			Sigstore: &sapi.IdentitySigstore{
+				Issuer: vo.ExpectedIssuer,
+				IdentityMatch: &sapi.StringMatcher{
+					Kind: &sapi.StringMatcher_Prefix{Prefix: vo.ExpectedSanPrefix},
+				},
+			},
+		})
+	}
+
+	for _, san := range vo.AlternateSans {
+		if san == "" {
+			continue
+		}
+		ids = append(ids, exactIdentity(vo.ExpectedIssuer, san))
+	}
+	return ids
+}
+
+// exactIdentity builds a sigstore identity matching the issuer and SAN exactly
+func exactIdentity(issuer, san string) *sapi.Identity {
+	return &sapi.Identity{
+		Sigstore: &sapi.IdentitySigstore{
+			Issuer:   issuer,
+			Identity: san,
+		},
+	}
+}
+
+// String describes the accepted identities for error messages
+func (vo *VerificationOptions) String() string {
+	sans := []string{}
+	switch {
+	case vo.ExpectedSan != "":
+		sans = append(sans, vo.ExpectedSan)
+	case vo.ExpectedSanPrefix != "":
+		sans = append(sans, vo.ExpectedSanPrefix+"*")
+	}
+	for _, san := range vo.AlternateSans {
+		if san != "" {
+			sans = append(sans, san)
+		}
+	}
+	return fmt.Sprintf("issuer %q identities %q", vo.ExpectedIssuer, sans)
 }
 
 type Verifier interface {
@@ -64,18 +140,23 @@ type BndVerifier struct {
 	Options VerificationOptions
 }
 
+// Verify checks a signed bundle, ensuring the signer matches the expected
+// identity. Note that this method does not accept the alternate identities,
+// only the expected SAN (or prefix) is checked.
 func (bv *BndVerifier) Verify(data string) (*verify.VerificationResult, error) {
-	// TODO: There's more for us to do here... but what?
-	// Maybe check to make sure it's from the identity we expect (the workflow?)
 	verifier := signer.NewVerifier()
 
+	identityOpts := []options.VerificationOptFunc{
+		options.WithExpectedIdentity(bv.Options.ExpectedIssuer, bv.Options.ExpectedSan),
+	}
+	if bv.Options.ExpectedSan == "" && bv.Options.ExpectedSanPrefix != "" {
+		identityOpts = append(identityOpts, options.WithExpectedIdentityRegex(
+			"", "^"+regexp.QuoteMeta(bv.Options.ExpectedSanPrefix),
+		))
+	}
+
 	// Verify the signed bundle
-	vr, err := verifier.VerifyInlineBundle(
-		[]byte(data),
-		options.WithExpectedIdentity(
-			bv.Options.ExpectedIssuer, bv.Options.ExpectedSan,
-		),
-	)
+	vr, err := verifier.VerifyInlineBundle([]byte(data), identityOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +164,8 @@ func (bv *BndVerifier) Verify(data string) (*verify.VerificationResult, error) {
 }
 
 // VerifyEnvelope verifies the signature of an attestation envelope fetched
-// by the collector and checks that the signer matches the expected identity
-// (issuer + SAN) or one of the accepted alternate identities.
+// by the collector and checks that the signer matches one of the expected
+// identities.
 func (bv *BndVerifier) VerifyEnvelope(env attestation.Envelope) error {
 	if env == nil {
 		return errors.New("unable to verify, envelope is nil")
@@ -104,24 +185,15 @@ func (bv *BndVerifier) VerifyEnvelope(env attestation.Envelope) error {
 		return errors.New("envelope carries no verified signature")
 	}
 
-	// Check the signer identity against the expected SANs
-	for _, san := range append([]string{bv.Options.ExpectedSan}, bv.Options.AlternateSans...) {
-		if san == "" {
-			continue
-		}
-		if verification.MatchesIdentity(&sapi.Identity{
-			Sigstore: &sapi.IdentitySigstore{
-				Issuer:   bv.Options.ExpectedIssuer,
-				Identity: san,
-			},
-		}) {
+	// Check the signer identity against the expected identities
+	for _, id := range bv.Options.expectedIdentities() {
+		if verification.MatchesIdentity(id) {
 			return nil
 		}
 	}
 
 	return fmt.Errorf(
-		"envelope signer does not match the expected identity (issuer %q identity %q)",
-		bv.Options.ExpectedIssuer, bv.Options.ExpectedSan,
+		"envelope signer does not match any expected identity (%s)", bv.Options.String(),
 	)
 }
 

--- a/pkg/attest/verify_test.go
+++ b/pkg/attest/verify_test.go
@@ -80,18 +80,57 @@ func TestVerifyEnvelope(t *testing.T) {
 		},
 		{
 			name:    "wrong-issuer",
-			env:     &fakeEnvelope{verification: signedBy("https://accounts.google.com", ExpectedSan)},
+			env:     &fakeEnvelope{verification: signedBy("https://accounts.google.com", ExpectedSanPrefix+"refs/heads/main")},
 			mustErr: true,
 		},
 		{
-			name: "expected-identity",
-			env:  &fakeEnvelope{verification: signedBy(ExpectedIssuer, ExpectedSan)},
+			// The workflow identity ends with whatever reference the
+			// user pinned it to: a digest, a tag or a branch.
+			name: "workflow-pinned-to-digest",
+			env:  &fakeEnvelope{verification: signedBy(ExpectedIssuer, ExpectedSanPrefix+"dea965cdca5e0cb422bf7b2653c9d15f678ad01c")},
+		},
+		{
+			name: "workflow-pinned-to-tag",
+			env:  &fakeEnvelope{verification: signedBy(ExpectedIssuer, ExpectedSanPrefix+"refs/tags/v0.1.0")},
+		},
+		{
+			name: "workflow-pinned-to-branch",
+			env:  &fakeEnvelope{verification: signedBy(ExpectedIssuer, ExpectedSanPrefix+"refs/heads/main")},
+		},
+		{
+			// A lookalike repository or workflow must not match the prefix
+			name:    "lookalike-repository",
+			env:     &fakeEnvelope{verification: signedBy(ExpectedIssuer, "https://github.com/slsa-framework/actions-fork/.github/workflows/compute_slsa_source.yml@refs/heads/main")},
+			mustErr: true,
+		},
+		{
+			name:    "lookalike-workflow",
+			env:     &fakeEnvelope{verification: signedBy(ExpectedIssuer, "https://github.com/slsa-framework/actions/.github/workflows/compute_slsa_source.yml.evil@refs/heads/main")},
+			mustErr: true,
+		},
+		{
+			name:    "other-workflow-in-actions-repo",
+			env:     &fakeEnvelope{verification: signedBy(ExpectedIssuer, "https://github.com/slsa-framework/actions/.github/workflows/release.yaml@refs/heads/main")},
+			mustErr: true,
+		},
+		{
+			// Attestations signed while the actions lived in the
+			// source-actions repository are still accepted.
+			name: "legacy-source-actions-identity",
+			env:  &fakeEnvelope{verification: signedBy(ExpectedIssuer, LegacySourceActionsSan)},
 		},
 		{
 			// Attestations signed before the repository split are
 			// still accepted (issue #255).
-			name: "old-identity",
-			env:  &fakeEnvelope{verification: signedBy(ExpectedIssuer, OldExpectedSan)},
+			name: "legacy-poc-identity",
+			env:  &fakeEnvelope{verification: signedBy(ExpectedIssuer, LegacyPocSan)},
+		},
+		{
+			// The legacy identities are matched exactly, other refs
+			// of the legacy workflows are not accepted.
+			name:    "legacy-workflow-other-ref",
+			env:     &fakeEnvelope{verification: signedBy(ExpectedIssuer, "https://github.com/slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@refs/heads/feature")},
+			mustErr: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,9 +159,53 @@ func TestVerifyEnvelopeCustomIdentity(t *testing.T) {
 
 	// ... and without alternates, the default identities don't
 	require.Error(t, custom.VerifyEnvelope(&fakeEnvelope{
-		verification: signedBy(ExpectedIssuer, ExpectedSan),
+		verification: signedBy(ExpectedIssuer, ExpectedSanPrefix+"refs/heads/main"),
 	}))
 	require.Error(t, custom.VerifyEnvelope(&fakeEnvelope{
-		verification: signedBy(ExpectedIssuer, OldExpectedSan),
+		verification: signedBy(ExpectedIssuer, LegacySourceActionsSan),
 	}))
+	require.Error(t, custom.VerifyEnvelope(&fakeEnvelope{
+		verification: signedBy(ExpectedIssuer, LegacyPocSan),
+	}))
+}
+
+func TestVerifyEnvelopeRequiresIssuer(t *testing.T) {
+	t.Parallel()
+	// Without an issuer, no identity is accepted (fail closed)
+	for _, opts := range []VerificationOptions{
+		{ExpectedSan: LegacySourceActionsSan},
+		{ExpectedSanPrefix: ExpectedSanPrefix},
+		{AlternateSans: []string{LegacyPocSan}},
+	} {
+		verifier := NewBndVerifier(opts)
+		require.Empty(t, opts.expectedIdentities())
+		require.Error(t, verifier.VerifyEnvelope(&fakeEnvelope{
+			verification: signedBy(ExpectedIssuer, LegacySourceActionsSan),
+		}))
+		require.Error(t, verifier.VerifyEnvelope(&fakeEnvelope{
+			verification: signedBy(ExpectedIssuer, ExpectedSanPrefix+"refs/heads/main"),
+		}))
+	}
+}
+
+func TestVerificationOptionsExpectedIdentities(t *testing.T) {
+	t.Parallel()
+	// The exact SAN takes precedence over the prefix, alternates are added
+	ids := (&VerificationOptions{
+		ExpectedIssuer:    ExpectedIssuer,
+		ExpectedSan:       "https://github.com/example/repo/.github/workflows/sign.yml@refs/heads/main",
+		ExpectedSanPrefix: ExpectedSanPrefix,
+		AlternateSans:     []string{"", LegacyPocSan},
+	}).expectedIdentities()
+	require.Len(t, ids, 2)
+	require.Equal(t, "https://github.com/example/repo/.github/workflows/sign.yml@refs/heads/main", ids[0].GetSigstore().GetIdentity())
+	require.Nil(t, ids[0].GetSigstore().GetIdentityMatch())
+	require.Equal(t, LegacyPocSan, ids[1].GetSigstore().GetIdentity())
+
+	// The defaults use the prefix plus the legacy identities
+	ids = DefaultVerifierOptions.expectedIdentities()
+	require.Len(t, ids, 3)
+	require.Empty(t, ids[0].GetSigstore().GetIdentity())
+	require.Equal(t, ExpectedSanPrefix, ids[0].GetSigstore().GetIdentityMatch().GetPrefix())
+	require.Equal(t, ExpectedIssuer, ids[0].GetSigstore().GetIssuer())
 }

--- a/pkg/attest/vsa.go
+++ b/pkg/attest/vsa.go
@@ -5,6 +5,7 @@ package attest
 
 import (
 	"fmt"
+	"slices"
 
 	vpb "github.com/in-toto/attestation/go/predicates/vsa/v1"
 	spb "github.com/in-toto/attestation/go/v1"
@@ -18,8 +19,32 @@ import (
 
 const (
 	VsaPredicateType = "https://slsa.dev/verification_summary/v1"
-	VsaVerifierId    = "https://github.com/slsa-framework/source-actions"
+
+	// VsaVerifierId identifies the verifier issuing the VSAs: the repository
+	// hosting the workflow that runs sourcetool to verify the source.
+	VsaVerifierId = "https://github.com/slsa-framework/actions"
+
+	// LegacySourceActionsVsaVerifierId is the verifier ID of the VSAs issued
+	// while the actions lived in slsa-framework/source-actions.
+	LegacySourceActionsVsaVerifierId = "https://github.com/slsa-framework/source-actions"
+
+	// LegacyPocVsaVerifierId is the verifier ID of the VSAs issued before the
+	// actions were split out of the slsa-source-poc repository.
+	LegacyPocVsaVerifierId = "https://github.com/slsa-framework/slsa-source-poc"
 )
+
+// AcceptedVsaVerifierIds lists the verifier IDs accepted when reading VSAs
+// from a repository: the current one and the legacy IDs found in VSAs
+// issued before the actions moved to their current repository.
+var AcceptedVsaVerifierIds = []string{
+	VsaVerifierId, LegacySourceActionsVsaVerifierId, LegacyPocVsaVerifierId,
+}
+
+// IsAcceptedVsaVerifierId returns true if the verifier ID is one of the IDs
+// accepted when reading VSAs.
+func IsAcceptedVsaVerifierId(id string) bool {
+	return slices.Contains(AcceptedVsaVerifierIds, id)
+}
 
 func CreateUnsignedSourceVsa(branch *models.Branch, commit *models.Commit, verifiedLevels slsa.SourceVerifiedLevels, policy string) (string, error) {
 	return createUnsignedSourceVsaAllParams(branch, commit, verifiedLevels, policy, VsaVerifierId, "PASSED")

--- a/pkg/attest/vsa_test.go
+++ b/pkg/attest/vsa_test.go
@@ -130,3 +130,13 @@ func TestCreateUnsignedSourceVsaSubjectAnnotation(t *testing.T) {
 	require.Len(t, refs, 1)
 	require.Equal(t, branch.FullRef(), refs[0].GetStringValue())
 }
+
+func TestIsAcceptedVsaVerifierId(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsAcceptedVsaVerifierId(VsaVerifierId))
+	require.True(t, IsAcceptedVsaVerifierId(LegacySourceActionsVsaVerifierId))
+	require.True(t, IsAcceptedVsaVerifierId(LegacyPocVsaVerifierId))
+	require.False(t, IsAcceptedVsaVerifierId(""))
+	require.False(t, IsAcceptedVsaVerifierId("https://github.com/attacker/actions"))
+	require.False(t, IsAcceptedVsaVerifierId(VsaVerifierId+"/"))
+}

--- a/pkg/sourcetool/backends/vcs/github/github.go
+++ b/pkg/sourcetool/backends/vcs/github/github.go
@@ -326,7 +326,7 @@ func (b *Backend) ControlConfigurationDescr(branch *models.Branch, config models
 		)
 	case models.CONFIG_GEN_PROVENANCE:
 		return fmt.Sprintf(
-			"Open a pull request on %s to add the provenance generation workflow",
+			"Open a pull request on %s to add or update the provenance generation workflow",
 			repo.Path,
 		)
 	case models.CONFIG_POLICY:

--- a/pkg/sourcetool/backends/vcs/github/manage.go
+++ b/pkg/sourcetool/backends/vcs/github/manage.go
@@ -33,6 +33,20 @@ const (
 	// workflowCommitMessage will be used as the commit message and the PR title
 	workflowCommitMessage = "Add SLSA Source Provenance Workflow"
 
+	// workflowUpdateCommitMessage is the commit message and PR title of the
+	// pull request updating workflows calling the actions from a legacy repo.
+	workflowUpdateCommitMessage = "Update SLSA Source Provenance Workflow"
+
+	// workflowUpdatePRBody is the body of the pull request updating the provenance
+	// workflow. It takes the current actions repo (twice) and the pinned tag.
+	workflowUpdatePRBody = `This pull request updates the SLSA Source provenance workflow to call the ` +
+		`SLSA actions from their new repository at [%s](https://github.com/%s).` + "\n\n" +
+		`The previous locations are deprecated and will no longer receive updates. ` +
+		`The actions are now pinned to the digest of the %s release, recording the ` +
+		`version in a comment so that dependabot can keep it up to date.` + "\n\n" +
+		`Note: This is an automated PR created using the ` +
+		`[SLSA sourcetool](https://github.com/slsa-framework/source-tool) utility.` + "\n"
+
 	// workflowPRBody is the body of the pull request that adds the provenance workflow
 	workflowPRBody = `This pull request adds a new workflow to the repository to generate ` +
 		`[SLSA](https://slsa.dev/) Source provenance data on every push.` + "\n\n" +
@@ -89,23 +103,124 @@ func (b *Backend) checkPushAccess(r *models.Repository) (bool, error) {
 
 // CreateWorkflowPR creates the pull request to add the provenance workflow
 // to the specified repository.
-func (b *Backend) CreateWorkflowPR(r *models.Repository, branches []*models.Branch) (*models.PullRequest, error) {
+func (b *Backend) CreateWorkflowPR(ctx context.Context, r *models.Repository, branches []*models.Branch) (*models.PullRequest, error) {
 	if len(branches) == 0 {
 		return nil, errors.New("no branches specified")
 	}
 
-	user, err := b.authenticator.WhoAmI()
-	if err != nil {
-		return nil, err
-	}
-
 	// Get the actions repo tag
-	actionsTag, actionsHash, err := b.GetLatestActionsTag()
+	actionsTag, actionsHash, err := b.GetLatestActionsTag(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting latest actions tag: %w", err)
 	}
 
 	workflowYAML := buildWorkflowYAML(branches, actionsTag, actionsHash)
+
+	//nolint:contextcheck // the pull request manager does not take a context
+	return b.openWorkflowPR(r, workflowCommitMessage, workflowPRBody, []*repo.PullRequestFileEntry{
+		{
+			Path:   workflowPath,
+			Reader: strings.NewReader(workflowYAML),
+		},
+	})
+}
+
+// updateWorkflowPR creates a pull request updating the specified workflows
+// to call the SLSA actions from the current repository, pinned to its latest
+// release. Workflows not calling any actions from a legacy repo are skipped.
+func (b *Backend) updateWorkflowPR(ctx context.Context, r *models.Repository, workflows []*provenanceWorkflow) (*models.PullRequest, error) {
+	// Get the actions repo tag
+	actionsTag, actionsHash, err := b.GetLatestActionsTag(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting latest actions tag: %w", err)
+	}
+
+	files := []*repo.PullRequestFileEntry{}
+	for _, wf := range workflows {
+		content, changed := migrateActionsReferences(wf.Content, actionsTag, actionsHash)
+		if changed == 0 {
+			continue
+		}
+		files = append(files, &repo.PullRequestFileEntry{
+			Path:   wf.Path,
+			Reader: strings.NewReader(content),
+		})
+	}
+
+	if len(files) == 0 {
+		return nil, errors.New("none of the workflows call the SLSA actions from a legacy repository")
+	}
+
+	actionsRepo := ActionsOrg + "/" + ActionsRepo
+	body := fmt.Sprintf(workflowUpdatePRBody, actionsRepo, actionsRepo, actionsTag)
+	//nolint:contextcheck // the pull request manager does not take a context
+	return b.openWorkflowPR(r, workflowUpdateCommitMessage, body, files)
+}
+
+// configureProvenanceWorkflow ensures the repository has a workflow generating
+// provenance which calls the current SLSA actions. It opens a pull request
+// adding the workflow when the repository has none, or updating the existing
+// workflows when they call the actions from a legacy repository. It returns
+// a nil pull request when there is nothing to do: either the workflows are up
+// to date or a pull request adding or updating them is already open.
+func (b *Backend) configureProvenanceWorkflow(ctx context.Context, r *models.Repository, branches []*models.Branch) (*models.PullRequest, error) {
+	// Check if there is an open PR already adding or updating the workflow
+	pr, err := b.FindWorkflowPR(ctx, r)
+	if err != nil {
+		return nil, fmt.Errorf("checking for an open workflow pull request: %w", err)
+	}
+	if pr != nil {
+		return nil, nil
+	}
+
+	owner, repoName, err := r.PathAsGitHubOwnerName()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := b.authenticator.GetGitHubClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting GitHub client: %w", err)
+	}
+
+	// Look for provenance workflows in the default branch, where the pull
+	// request will be opened. Workflows are detected by their contents, not
+	// by their file name.
+	workflows, err := findProvenanceWorkflows(ctx, client, owner, repoName, r.DefaultBranch)
+	if err != nil {
+		return nil, fmt.Errorf("checking for existing provenance workflows: %w", err)
+	}
+
+	// No workflow found, add it
+	if len(workflows) == 0 {
+		return b.CreateWorkflowPR(ctx, r, branches)
+	}
+
+	legacy := []*provenanceWorkflow{}
+	for _, wf := range workflows {
+		if wf.IsLegacy() {
+			legacy = append(legacy, wf)
+		}
+	}
+
+	// Workflows already call the current actions, nothing to do
+	if len(legacy) == 0 {
+		return nil, nil
+	}
+
+	return b.updateWorkflowPR(ctx, r, legacy)
+}
+
+// openWorkflowPR opens a pull request in the repository checking in the
+// specified files. If the user does not have push access to the repository,
+// the pull request is opened from the user's fork.
+func (b *Backend) openWorkflowPR(
+	r *models.Repository, title, body string, files []*repo.PullRequestFileEntry,
+) (*models.PullRequest, error) {
+	user, err := b.authenticator.WhoAmI()
+	if err != nil {
+		return nil, err
+	}
 
 	// We need to determine if the user needs a fork
 	hasPush, err := b.checkPushAccess(r)
@@ -128,19 +243,14 @@ func (b *Backend) CreateWorkflowPR(r *models.Repository, branches []*models.Bran
 	pr, err := prManager.PullRequestFileList(
 		r,
 		&options.PullRequestFileListOptions{
-			Title: workflowCommitMessage,
-			Body:  workflowPRBody,
+			Title: title,
+			Body:  body,
 			CommitOptions: options.CommitOptions{
 				Name:  user.GetLogin(),
 				Email: commitEmailForActor(user),
 			},
 		},
-		[]*repo.PullRequestFileEntry{
-			{
-				Path:   workflowPath,
-				Reader: strings.NewReader(workflowYAML),
-			},
-		},
+		files,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating workflow pull request: %w", err)
@@ -186,18 +296,9 @@ func (b *Backend) CheckWorkflowFork(r *models.Repository) error {
 	return err
 }
 
-// searchPullRequestsByTitlet searches the last pull requests on a repo for one whose
-// title matches the query string
-func (b *Backend) searchPullRequestsByTitle(ctx context.Context, r *models.Repository, query string) (*github.PullRequest, error) {
-	owner, repoName, err := r.PathAsGitHubOwnerName()
-	if err != nil {
-		return nil, err
-	}
-	client, err := b.authenticator.GetGitHubClient()
-	if err != nil {
-		return nil, err
-	}
-
+// searchPullRequestsByTitle searches the last open pull requests of a repo for
+// the first one whose title contains any of the query strings.
+func searchPullRequestsByTitle(ctx context.Context, client *github.Client, owner, repoName string, queries ...string) (*github.PullRequest, error) {
 	prs, _, err := client.PullRequests.List(
 		ctx, owner, repoName, &github.PullRequestListOptions{
 			State: "open",
@@ -213,15 +314,31 @@ func (b *Backend) searchPullRequestsByTitle(ctx context.Context, r *models.Repos
 	}
 
 	for _, pr := range prs {
-		if strings.Contains(pr.GetTitle(), query) {
-			return pr, nil
+		for _, query := range queries {
+			if strings.Contains(pr.GetTitle(), query) {
+				return pr, nil
+			}
 		}
 	}
 	return nil, nil
 }
 
+// FindWorkflowPR looks for an open pull request adding or updating the
+// provenance workflow in the repository. Returns nil if none is found.
 func (b *Backend) FindWorkflowPR(ctx context.Context, r *models.Repository) (*models.PullRequest, error) {
-	pr, err := b.searchPullRequestsByTitle(ctx, r, workflowCommitMessage)
+	owner, repoName, err := r.PathAsGitHubOwnerName()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := b.authenticator.GetGitHubClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting GitHub client: %w", err)
+	}
+
+	pr, err := searchPullRequestsByTitle(
+		ctx, client, owner, repoName, workflowCommitMessage, workflowUpdateCommitMessage,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("searching for provenance workflow pull request: %w", err)
 	}
@@ -361,18 +478,9 @@ func (b *Backend) ConfigureControls(r *models.Repository, branches []*models.Bra
 				}
 			}
 		case models.CONFIG_GEN_PROVENANCE:
-			pr, err := b.FindWorkflowPR(context.Background(), r)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("checking repository pull request: %w", err))
-			}
-
-			if pr != nil {
-				continue
-			}
-
-			if _, err := b.CreateWorkflowPR(r, branches); err != nil {
+			if _, err := b.configureProvenanceWorkflow(context.Background(), r, branches); err != nil {
 				if !errors.Is(err, models.ErrProtectionAlreadyInPlace) {
-					errs = append(errs, fmt.Errorf("opening SLSA source workflow pull request: %w", err))
+					errs = append(errs, fmt.Errorf("configuring SLSA source workflow: %w", err))
 				}
 			}
 		case models.CONFIG_TAG_RULES:
@@ -392,13 +500,13 @@ func (b *Backend) ConfigureControls(r *models.Repository, branches []*models.Bra
 
 // GetLatestActionsTag queries GitHub and returns the name and commit digest
 // of the latest release tag of the actions repository (ActionsOrg/ActionsRepo).
-func (b *Backend) GetLatestActionsTag() (tag, digest string, err error) {
+func (b *Backend) GetLatestActionsTag(ctx context.Context) (tag, digest string, err error) {
 	client, err := b.authenticator.GetGitHubClient()
 	if err != nil {
 		return "", "", fmt.Errorf("getting GitHub client: %w", err)
 	}
 
-	return latestActionsTag(context.Background(), client)
+	return latestActionsTag(ctx, client)
 }
 
 // latestActionsTag lists all the tags of the actions repository and returns

--- a/pkg/sourcetool/backends/vcs/github/manage_test.go
+++ b/pkg/sourcetool/backends/vcs/github/manage_test.go
@@ -86,6 +86,59 @@ func TestLatestReleaseTag(t *testing.T) {
 	}
 }
 
+func TestSearchPullRequestsByTitle(t *testing.T) {
+	t.Parallel()
+	openPRs := []*github.PullRequest{
+		{Number: github.Ptr(1), Title: github.Ptr("Bump something")},
+		{Number: github.Ptr(2), Title: github.Ptr(workflowUpdateCommitMessage)},
+		{Number: github.Ptr(3), Title: github.Ptr(workflowCommitMessage)},
+	}
+	for _, tc := range []struct {
+		name         string
+		prs          []*github.PullRequest
+		queries      []string
+		expectNumber int
+	}{
+		{"no-prs", []*github.PullRequest{}, []string{workflowCommitMessage}, 0},
+		{"no-match", openPRs, []string{"Something else"}, 0},
+		{"add-pr", openPRs, []string{workflowCommitMessage}, 3},
+		{"update-pr", openPRs, []string{workflowUpdateCommitMessage}, 2},
+		{"any-of", openPRs, []string{workflowCommitMessage, workflowUpdateCommitMessage}, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, err := github.NewClient(github.WithHTTPClient(mock.NewMockedHTTPClient(
+				mock.WithRequestMatch(mock.GetReposPullsByOwnerByRepo, tc.prs),
+			)))
+			require.NoError(t, err)
+
+			pr, err := searchPullRequestsByTitle(t.Context(), client, "owner", "repo", tc.queries...)
+			require.NoError(t, err)
+			if tc.expectNumber == 0 {
+				assert.Nil(t, pr)
+				return
+			}
+			require.NotNil(t, pr)
+			assert.Equal(t, tc.expectNumber, pr.GetNumber())
+		})
+	}
+
+	t.Run("api-error", func(t *testing.T) {
+		t.Parallel()
+		client, err := github.NewClient(github.WithHTTPClient(mock.NewMockedHTTPClient(
+			mock.WithRequestMatchHandler(
+				mock.GetReposPullsByOwnerByRepo,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					mock.WriteError(w, http.StatusInternalServerError, "boom")
+				}),
+			),
+		)))
+		require.NoError(t, err)
+		_, err = searchPullRequestsByTitle(t.Context(), client, "owner", "repo", workflowCommitMessage)
+		require.Error(t, err)
+	})
+}
+
 func TestLatestActionsTag(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/pkg/sourcetool/backends/vcs/github/workflow.go
+++ b/pkg/sourcetool/backends/vcs/github/workflow.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"path"
 	"regexp"
@@ -22,12 +23,13 @@ import (
 // workflowsDir is the directory where GitHub looks for actions workflows
 const workflowsDir = ".github/workflows"
 
-// legacyActionsRepos lists the repositories that hosted the SLSA source
-// actions before they moved to ActionsOrg/ActionsRepo. Workflows calling
-// actions from these locations need to be updated.
-var legacyActionsRepos = []string{
-	"slsa-framework/source-actions",
-	"slsa-framework/slsa-source-poc",
+// legacyActionsRepos maps the repositories that hosted the SLSA source
+// actions before they moved to ActionsOrg/ActionsRepo to the directory the
+// actions lived in. Workflows calling actions from these locations need to
+// be updated.
+var legacyActionsRepos = map[string]string{
+	"slsa-framework/source-actions":  "",
+	"slsa-framework/slsa-source-poc": "actions/",
 }
 
 // actionsUsesRegexp matches the `uses:` lines of a workflow calling an action
@@ -40,7 +42,7 @@ var actionsUsesRegexp = buildActionsUsesRegexp()
 func buildActionsUsesRegexp() *regexp.Regexp {
 	repos := make([]string, 0, len(legacyActionsRepos)+1)
 	repos = append(repos, regexp.QuoteMeta(ActionsOrg+"/"+ActionsRepo))
-	for _, r := range legacyActionsRepos {
+	for _, r := range slices.Sorted(maps.Keys(legacyActionsRepos)) {
 		repos = append(repos, regexp.QuoteMeta(r))
 	}
 	return regexp.MustCompile(
@@ -64,7 +66,14 @@ type actionsReference struct {
 // IsLegacy returns true when the reference calls the action from a
 // repository that no longer hosts the SLSA actions.
 func (ar *actionsReference) IsLegacy() bool {
-	return slices.Contains(legacyActionsRepos, ar.Repo)
+	_, ok := legacyActionsRepos[ar.Repo]
+	return ok
+}
+
+// CurrentPath returns the path of the referenced action in the current
+// actions repository (ActionsOrg/ActionsRepo).
+func (ar *actionsReference) CurrentPath() string {
+	return strings.TrimPrefix(ar.Path, legacyActionsRepos[ar.Repo])
 }
 
 // findActionsReferences scans the contents of a workflow file and returns all
@@ -84,6 +93,30 @@ func findActionsReferences(content string) []*actionsReference {
 		})
 	}
 	return refs
+}
+
+// migrateActionsReferences rewrites the references to the SLSA actions found
+// in a workflow which still call them from a legacy repository. The rewritten
+// references call the actions from ActionsOrg/ActionsRepo pinned to the digest
+// of the specified tag, recording the tag in a comment so that dependabot can
+// keep the pin updated. Returns the new contents and the number of lines changed.
+func migrateActionsReferences(content, tag, digest string) (migrated string, changed int) {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		m := actionsUsesRegexp.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ref := &actionsReference{Repo: m[2], Path: m[3], Ref: m[4]}
+		if !ref.IsLegacy() {
+			continue
+		}
+		lines[i] = fmt.Sprintf(
+			"%s%s/%s/%s@%s%s # %s", m[1], ActionsOrg, ActionsRepo, ref.CurrentPath(), digest, m[5], tag,
+		)
+		changed++
+	}
+	return strings.Join(lines, "\n"), changed
 }
 
 // workflowFile is a GitHub actions workflow read from a repository
@@ -140,6 +173,12 @@ type provenanceWorkflow struct {
 	*workflowFile
 	// References are the calls to the SLSA actions found in the workflow
 	References []*actionsReference
+}
+
+// IsLegacy returns true when the workflow calls any of the SLSA actions
+// from a legacy repository.
+func (pw *provenanceWorkflow) IsLegacy() bool {
+	return slices.ContainsFunc(pw.References, func(ref *actionsReference) bool { return ref.IsLegacy() })
 }
 
 // LegacyRepos returns the deduplicated list of legacy repositories the

--- a/pkg/sourcetool/backends/vcs/github/workflow.go
+++ b/pkg/sourcetool/backends/vcs/github/workflow.go
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: Copyright 2026 The SLSA Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/google/go-github/v88/github"
+
+	"github.com/slsa-framework/source-tool/pkg/slsa"
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+)
+
+// workflowsDir is the directory where GitHub looks for actions workflows
+const workflowsDir = ".github/workflows"
+
+// legacyActionsRepos lists the repositories that hosted the SLSA source
+// actions before they moved to ActionsOrg/ActionsRepo. Workflows calling
+// actions from these locations need to be updated.
+var legacyActionsRepos = []string{
+	"slsa-framework/source-actions",
+	"slsa-framework/slsa-source-poc",
+}
+
+// actionsUsesRegexp matches the `uses:` lines of a workflow calling an action
+// or a reusable workflow hosted in the current or any of the legacy SLSA
+// actions repositories. The submatches capture the line prefix (up to and
+// including any opening quote), the repository, the path of the action in the
+// repository, the git reference, the closing quote and any trailing comment.
+var actionsUsesRegexp = buildActionsUsesRegexp()
+
+func buildActionsUsesRegexp() *regexp.Regexp {
+	repos := make([]string, 0, len(legacyActionsRepos)+1)
+	repos = append(repos, regexp.QuoteMeta(ActionsOrg+"/"+ActionsRepo))
+	for _, r := range legacyActionsRepos {
+		repos = append(repos, regexp.QuoteMeta(r))
+	}
+	return regexp.MustCompile(
+		`^(\s*(?:-\s+)?uses:\s*["']?)(` + strings.Join(repos, "|") + `)/([^@\s"']+)@([^\s"'#]+)(["']?)(\s*#.*)?\s*$`,
+	)
+}
+
+// actionsReference is a reference to a SLSA action or reusable workflow
+// found in a workflow file.
+type actionsReference struct {
+	// Line is the 1-based line number where the reference was found
+	Line int
+	// Repo is the GitHub repository (owner/name) hosting the action
+	Repo string
+	// Path of the action or reusable workflow inside the repository
+	Path string
+	// Ref is the git reference (branch, tag or digest) the action is pinned to
+	Ref string
+}
+
+// IsLegacy returns true when the reference calls the action from a
+// repository that no longer hosts the SLSA actions.
+func (ar *actionsReference) IsLegacy() bool {
+	return slices.Contains(legacyActionsRepos, ar.Repo)
+}
+
+// findActionsReferences scans the contents of a workflow file and returns all
+// the references to the SLSA actions it finds, current or legacy.
+func findActionsReferences(content string) []*actionsReference {
+	refs := []*actionsReference{}
+	for i, line := range strings.Split(content, "\n") {
+		m := actionsUsesRegexp.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		refs = append(refs, &actionsReference{
+			Line: i + 1,
+			Repo: m[2],
+			Path: m[3],
+			Ref:  m[4],
+		})
+	}
+	return refs
+}
+
+// workflowFile is a GitHub actions workflow read from a repository
+type workflowFile struct {
+	// Path of the workflow file, relative to the repository root
+	Path string
+	// Content is the raw workflow file
+	Content string
+}
+
+// readWorkflowFiles returns all the workflow files found in the repository
+// at the specified git reference. If ref is empty, the repository default
+// branch is read. Repositories without workflows return an empty list.
+func readWorkflowFiles(ctx context.Context, client *github.Client, owner, repoName, ref string) ([]*workflowFile, error) {
+	opts := &github.RepositoryContentGetOptions{Ref: ref}
+	_, entries, resp, err := client.Repositories.GetContents(ctx, owner, repoName, workflowsDir, opts)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing %s: %w", workflowsDir, err)
+	}
+
+	files := []*workflowFile{}
+	for _, entry := range entries {
+		if entry.GetType() != "file" {
+			continue
+		}
+		if ext := strings.ToLower(path.Ext(entry.GetName())); ext != ".yml" && ext != ".yaml" {
+			continue
+		}
+
+		content, _, _, err := client.Repositories.GetContents(ctx, owner, repoName, entry.GetPath(), opts)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", entry.GetPath(), err)
+		}
+		if content == nil {
+			return nil, fmt.Errorf("reading %s: no file contents returned", entry.GetPath())
+		}
+		data, err := content.GetContent()
+		if err != nil {
+			return nil, fmt.Errorf("decoding %s: %w", entry.GetPath(), err)
+		}
+		files = append(files, &workflowFile{
+			Path:    entry.GetPath(),
+			Content: data,
+		})
+	}
+	return files, nil
+}
+
+// provenanceWorkflow is a workflow file calling the SLSA source actions
+type provenanceWorkflow struct {
+	*workflowFile
+	// References are the calls to the SLSA actions found in the workflow
+	References []*actionsReference
+}
+
+// LegacyRepos returns the deduplicated list of legacy repositories the
+// workflow calls actions from, in the order they appear in the file.
+func (pw *provenanceWorkflow) LegacyRepos() []string {
+	repos := []string{}
+	for _, ref := range pw.References {
+		if ref.IsLegacy() && !slices.Contains(repos, ref.Repo) {
+			repos = append(repos, ref.Repo)
+		}
+	}
+	return repos
+}
+
+// toModel returns the public representation of the workflow, including the
+// recommended action to update it when it calls actions from a legacy repo.
+func (pw *provenanceWorkflow) toModel(repo *models.Repository) *models.ProvenanceWorkflow {
+	res := &models.ProvenanceWorkflow{
+		Path:               pw.Path,
+		LegacyActionsRepos: pw.LegacyRepos(),
+	}
+	if res.IsLegacy() {
+		res.RecommendedAction = &slsa.ControlRecommendedAction{
+			Message: fmt.Sprintf(
+				"Update %s to call the SLSA actions from %s/%s", pw.Path, ActionsOrg, ActionsRepo,
+			),
+			Command: fmt.Sprintf(
+				"sourcetool setup controls --config=%s %s", models.CONFIG_GEN_PROVENANCE, repo.Path,
+			),
+		}
+	}
+	return res
+}
+
+// findProvenanceWorkflows reads the workflows of a repository at the
+// specified git reference and returns those calling the SLSA source actions.
+func findProvenanceWorkflows(ctx context.Context, client *github.Client, owner, repoName, ref string) ([]*provenanceWorkflow, error) {
+	files, err := readWorkflowFiles(ctx, client, owner, repoName, ref)
+	if err != nil {
+		return nil, fmt.Errorf("reading repository workflows: %w", err)
+	}
+
+	workflows := []*provenanceWorkflow{}
+	for _, f := range files {
+		refs := findActionsReferences(f.Content)
+		if len(refs) == 0 {
+			continue
+		}
+		workflows = append(workflows, &provenanceWorkflow{
+			workflowFile: f,
+			References:   refs,
+		})
+	}
+	return workflows, nil
+}
+
+// FindProvenanceWorkflows returns the workflows in the branch that call the
+// SLSA source actions, flagging those still calling them from a legacy
+// repository.
+func (b *Backend) FindProvenanceWorkflows(ctx context.Context, branch *models.Branch) ([]*models.ProvenanceWorkflow, error) {
+	if branch == nil || branch.Repository == nil {
+		return nil, errors.New("branch has no repository")
+	}
+
+	owner, repoName, err := branch.Repository.PathAsGitHubOwnerName()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := b.authenticator.GetGitHubClient()
+	if err != nil {
+		return nil, fmt.Errorf("getting GitHub client: %w", err)
+	}
+
+	workflows, err := findProvenanceWorkflows(ctx, client, owner, repoName, branch.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]*models.ProvenanceWorkflow, 0, len(workflows))
+	for _, wf := range workflows {
+		res = append(res, wf.toModel(branch.Repository))
+	}
+	return res, nil
+}

--- a/pkg/sourcetool/backends/vcs/github/workflow_test.go
+++ b/pkg/sourcetool/backends/vcs/github/workflow_test.go
@@ -121,6 +121,82 @@ func TestActionsReferenceIsLegacy(t *testing.T) {
 	assert.False(t, (&actionsReference{Repo: "slsa-framework/actions"}).IsLegacy())
 }
 
+func TestActionsReferenceCurrentPath(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		repo, path, expect string
+	}{
+		{"slsa-framework/source-actions", ".github/workflows/compute_slsa_source.yml", ".github/workflows/compute_slsa_source.yml"},
+		{"slsa-framework/source-actions", "slsa_with_provenance", "slsa_with_provenance"},
+		{"slsa-framework/slsa-source-poc", ".github/workflows/compute_slsa_source.yml", ".github/workflows/compute_slsa_source.yml"},
+		{"slsa-framework/slsa-source-poc", "actions/slsa_with_provenance", "slsa_with_provenance"},
+		{"slsa-framework/actions", "store_note", "store_note"},
+	} {
+		assert.Equal(t, tc.expect, (&actionsReference{Repo: tc.repo, Path: tc.path}).CurrentPath(), tc.repo+"/"+tc.path)
+	}
+}
+
+func TestMigrateActionsReferences(t *testing.T) {
+	t.Parallel()
+	const (
+		tag    = "v0.1.0"
+		digest = "dea965cdca5e0cb422bf7b2653c9d15f678ad01c"
+	)
+	for _, tc := range []struct {
+		name          string
+		content       string
+		expect        string
+		expectChanged int
+	}{
+		{"empty", "", "", 0},
+		{"unrelated", unrelatedWorkflow, unrelatedWorkflow, 0},
+		{"already-current", currentWorkflow, currentWorkflow, 0},
+		{
+			"reusable-workflow",
+			legacyWorkflow,
+			strings.Replace(
+				legacyWorkflow,
+				"    uses: slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@main",
+				"    uses: slsa-framework/actions/.github/workflows/compute_slsa_source.yml@"+digest+" # "+tag,
+				1,
+			),
+			1,
+		},
+		{
+			// The poc repo hosted the actions under actions/, the path is fixed
+			"poc-action-path",
+			"    steps:\n    - name: prov\n      uses: slsa-framework/slsa-source-poc/actions/slsa_with_provenance@main\n      with:\n        version: v0.6.2\n",
+			"    steps:\n    - name: prov\n      uses: slsa-framework/actions/slsa_with_provenance@" + digest + " # " + tag + "\n      with:\n        version: v0.6.2\n",
+			1,
+		},
+		{
+			// Quotes are preserved and old comments replaced
+			"quoted-with-comment",
+			`  uses: "slsa-framework/source-actions/get_note@abc123" # v0.0.1` + "\n",
+			`  uses: "slsa-framework/actions/get_note@` + digest + `" # ` + tag + "\n",
+			1,
+		},
+		{
+			"mixed-references",
+			"    - uses: slsa-framework/source-actions/get_note@main\n    - uses: actions/checkout@v4\n    - uses: slsa-framework/actions/store_note@abc123 # v0.0.9\n    - uses: slsa-framework/slsa-source-poc/actions/store_note@main\n",
+			"    - uses: slsa-framework/actions/get_note@" + digest + " # " + tag + "\n    - uses: actions/checkout@v4\n    - uses: slsa-framework/actions/store_note@abc123 # v0.0.9\n    - uses: slsa-framework/actions/store_note@" + digest + " # " + tag + "\n",
+			2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, changed := migrateActionsReferences(tc.content, tag, digest)
+			assert.Equal(t, tc.expectChanged, changed)
+			assert.Equal(t, tc.expect, res)
+
+			// Migrated content must not reference any legacy repo anymore
+			for _, ref := range findActionsReferences(res) {
+				assert.False(t, ref.IsLegacy(), "line %d still references %s", ref.Line, ref.Repo)
+			}
+		})
+	}
+}
+
 // contentsHandler returns a mock handler for the repository contents API
 // serving the workflows directory listing and the file contents from files.
 func contentsHandler(t *testing.T, files map[string]string) http.Handler {

--- a/pkg/sourcetool/backends/vcs/github/workflow_test.go
+++ b/pkg/sourcetool/backends/vcs/github/workflow_test.go
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: Copyright 2026 The SLSA Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/slsa-framework/source-tool/pkg/sourcetool/models"
+)
+
+const (
+	legacyWorkflow = `---
+name: SLSA Source
+on:
+  push:
+    branches: [ "main" ]
+jobs:
+  generate-provenance:
+    permissions:
+      contents: write
+      id-token: write
+    uses: slsa-framework/source-actions/.github/workflows/compute_slsa_source.yml@main
+`
+	currentWorkflow = `---
+name: SLSA Source
+jobs:
+  generate-provenance:
+    uses: slsa-framework/actions/.github/workflows/compute_slsa_source.yml@dea965cdca5e0cb422bf7b2653c9d15f678ad01c # v0.1.0
+`
+	unrelatedWorkflow = `---
+name: Tests
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test ./...
+`
+)
+
+func TestFindActionsReferences(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		content string
+		expect  []*actionsReference
+	}{
+		{"empty", "", nil},
+		{"no-references", unrelatedWorkflow, nil},
+		{
+			"reusable-workflow-legacy",
+			legacyWorkflow,
+			[]*actionsReference{{
+				Line: 11, Repo: "slsa-framework/source-actions",
+				Path: ".github/workflows/compute_slsa_source.yml", Ref: "main",
+			}},
+		},
+		{
+			"reusable-workflow-current-pinned",
+			currentWorkflow,
+			[]*actionsReference{{
+				Line: 5, Repo: "slsa-framework/actions",
+				Path: ".github/workflows/compute_slsa_source.yml", Ref: "dea965cdca5e0cb422bf7b2653c9d15f678ad01c",
+			}},
+		},
+		{
+			"step-action-poc-repo",
+			"    steps:\n    - name: prov\n      uses: slsa-framework/slsa-source-poc/actions/slsa_with_provenance@main\n",
+			[]*actionsReference{{
+				Line: 3, Repo: "slsa-framework/slsa-source-poc",
+				Path: "actions/slsa_with_provenance", Ref: "main",
+			}},
+		},
+		{
+			"quoted-reference",
+			`      - uses: "slsa-framework/source-actions/slsa_with_provenance@v0.1.0"` + "\n",
+			[]*actionsReference{{
+				Line: 1, Repo: "slsa-framework/source-actions",
+				Path: "slsa_with_provenance", Ref: "v0.1.0",
+			}},
+		},
+		{
+			"multiple-references",
+			"    - uses: slsa-framework/source-actions/get_note@main\n    - uses: actions/checkout@v4\n    - uses: slsa-framework/actions/store_note@abc123 # v0.1.0\n",
+			[]*actionsReference{
+				{Line: 1, Repo: "slsa-framework/source-actions", Path: "get_note", Ref: "main"},
+				{Line: 3, Repo: "slsa-framework/actions", Path: "store_note", Ref: "abc123"},
+			},
+		},
+		{
+			// Commented out lines and repos with similar names are ignored
+			"ignored-lines",
+			"    # uses: slsa-framework/source-actions/get_note@main\n    - uses: slsa-framework/actions-fork/get_note@main\n    - uses: other-org/source-actions/get_note@main\n",
+			nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			refs := findActionsReferences(tc.content)
+			if tc.expect == nil {
+				assert.Empty(t, refs)
+				return
+			}
+			assert.Equal(t, tc.expect, refs)
+		})
+	}
+}
+
+func TestActionsReferenceIsLegacy(t *testing.T) {
+	t.Parallel()
+	assert.True(t, (&actionsReference{Repo: "slsa-framework/source-actions"}).IsLegacy())
+	assert.True(t, (&actionsReference{Repo: "slsa-framework/slsa-source-poc"}).IsLegacy())
+	assert.False(t, (&actionsReference{Repo: "slsa-framework/actions"}).IsLegacy())
+}
+
+// contentsHandler returns a mock handler for the repository contents API
+// serving the workflows directory listing and the file contents from files.
+func contentsHandler(t *testing.T, files map[string]string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Directory listing
+		if strings.HasSuffix(r.URL.Path, "/contents/"+workflowsDir) {
+			listing := make([]*github.RepositoryContent, 0, len(files)+2)
+			listing = append(listing,
+				&github.RepositoryContent{Type: github.Ptr("dir"), Name: github.Ptr("scripts"), Path: github.Ptr(workflowsDir + "/scripts")},
+				&github.RepositoryContent{Type: github.Ptr("file"), Name: github.Ptr("README.md"), Path: github.Ptr(workflowsDir + "/README.md")},
+			)
+			for name := range files {
+				listing = append(listing, &github.RepositoryContent{
+					Type: github.Ptr("file"), Name: github.Ptr(name), Path: github.Ptr(workflowsDir + "/" + name),
+				})
+			}
+			_, err := w.Write(mock.MustMarshal(listing))
+			assert.NoError(t, err)
+			return
+		}
+
+		// File contents
+		for name, content := range files {
+			if !strings.HasSuffix(r.URL.Path, "/contents/"+workflowsDir+"/"+name) {
+				continue
+			}
+			_, err := w.Write(mock.MustMarshal(&github.RepositoryContent{
+				Type:     github.Ptr("file"),
+				Name:     github.Ptr(name),
+				Path:     github.Ptr(workflowsDir + "/" + name),
+				Encoding: github.Ptr("base64"),
+				Content:  github.Ptr(base64.StdEncoding.EncodeToString([]byte(content))),
+			}))
+			assert.NoError(t, err)
+			return
+		}
+		mock.WriteError(w, http.StatusNotFound, "not found")
+	})
+}
+
+func TestFindProvenanceWorkflows(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		mockOption mock.MockBackendOption
+		expect     []*models.ProvenanceWorkflow
+		mustErr    bool
+	}{
+		{
+			name: "legacy-and-current",
+			mockOption: mock.WithRequestMatchHandler(
+				mock.GetReposContentsByOwnerByRepoByPath,
+				contentsHandler(t, map[string]string{
+					"legacy.yml":  legacyWorkflow,
+					"slsa.yaml":   currentWorkflow,
+					"tests.yml":   unrelatedWorkflow,
+					"notes.txt":   legacyWorkflow, // not a workflow, must be skipped
+					"nested.YAML": "    - uses: slsa-framework/slsa-source-poc/actions/get_note@main\n    - uses: slsa-framework/source-actions/store_note@main\n",
+				}),
+			),
+			expect: []*models.ProvenanceWorkflow{
+				{
+					Path:               workflowsDir + "/legacy.yml",
+					LegacyActionsRepos: []string{"slsa-framework/source-actions"},
+				},
+				{
+					Path:               workflowsDir + "/nested.YAML",
+					LegacyActionsRepos: []string{"slsa-framework/slsa-source-poc", "slsa-framework/source-actions"},
+				},
+				{
+					Path:               workflowsDir + "/slsa.yaml",
+					LegacyActionsRepos: []string{},
+				},
+			},
+		},
+		{
+			name: "no-workflows-dir",
+			mockOption: mock.WithRequestMatchHandler(
+				mock.GetReposContentsByOwnerByRepoByPath,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					mock.WriteError(w, http.StatusNotFound, "not found")
+				}),
+			),
+			expect: []*models.ProvenanceWorkflow{},
+		},
+		{
+			name: "no-provenance-workflows",
+			mockOption: mock.WithRequestMatchHandler(
+				mock.GetReposContentsByOwnerByRepoByPath,
+				contentsHandler(t, map[string]string{"tests.yml": unrelatedWorkflow}),
+			),
+			expect: []*models.ProvenanceWorkflow{},
+		},
+		{
+			name: "api-error",
+			mockOption: mock.WithRequestMatchHandler(
+				mock.GetReposContentsByOwnerByRepoByPath,
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					mock.WriteError(w, http.StatusInternalServerError, "boom")
+				}),
+			),
+			mustErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client, err := github.NewClient(github.WithHTTPClient(mock.NewMockedHTTPClient(tc.mockOption)))
+			require.NoError(t, err)
+
+			workflows, err := findProvenanceWorkflows(t.Context(), client, "owner", "repo", "main")
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Sort by path as the mock directory listing order is not stable
+			res := make([]*models.ProvenanceWorkflow, 0, len(workflows))
+			for _, wf := range workflows {
+				res = append(res, wf.toModel(&models.Repository{Path: "owner/repo"}))
+			}
+			sortWorkflows(res)
+
+			require.Len(t, res, len(tc.expect))
+			for i := range tc.expect {
+				assert.Equal(t, tc.expect[i].Path, res[i].Path)
+				assert.Equal(t, tc.expect[i].LegacyActionsRepos, res[i].LegacyActionsRepos)
+				assert.Equal(t, tc.expect[i].IsLegacy(), res[i].IsLegacy())
+				if tc.expect[i].IsLegacy() {
+					require.NotNil(t, res[i].RecommendedAction)
+					assert.Contains(t, res[i].RecommendedAction.Message, res[i].Path)
+					assert.Contains(t, res[i].RecommendedAction.Message, ActionsOrg+"/"+ActionsRepo)
+					assert.Equal(
+						t, "sourcetool setup controls --config=CONFIG_GEN_PROVENANCE owner/repo",
+						res[i].RecommendedAction.Command,
+					)
+				} else {
+					assert.Nil(t, res[i].RecommendedAction)
+				}
+			}
+		})
+	}
+}
+
+func sortWorkflows(workflows []*models.ProvenanceWorkflow) {
+	for i := range workflows {
+		for j := i + 1; j < len(workflows); j++ {
+			if workflows[j].Path < workflows[i].Path {
+				workflows[i], workflows[j] = workflows[j], workflows[i]
+			}
+		}
+	}
+}

--- a/pkg/sourcetool/models/models.go
+++ b/pkg/sourcetool/models/models.go
@@ -49,6 +49,7 @@ type VcsBackend interface {
 	GetPreviousCommit(context.Context, *Branch, *Commit) (*Commit, error)
 	GetDefaultBranch(context.Context, *Repository) (*Branch, error)
 	GetRevisionCommit(context.Context, *Repository, Revision) (*Commit, error)
+	FindProvenanceWorkflows(context.Context, *Branch) ([]*ProvenanceWorkflow, error)
 }
 
 type BackendOptions struct {
@@ -199,6 +200,27 @@ type PullRequest struct {
 	Base   string // main
 	Number int
 	Repo   *Repository
+}
+
+// ProvenanceWorkflow describes a CI workflow found in a repository that calls
+// the SLSA source actions to generate provenance.
+type ProvenanceWorkflow struct {
+	// Path of the workflow file, relative to the repository root
+	Path string
+
+	// LegacyActionsRepos lists the deprecated repositories the workflow still
+	// calls the SLSA actions from. When empty, the workflow is up to date.
+	LegacyActionsRepos []string
+
+	// RecommendedAction describes how to bring the workflow up to date. It
+	// is nil when the workflow does not need any changes.
+	RecommendedAction *slsa.ControlRecommendedAction
+}
+
+// IsLegacy returns true when the workflow calls the SLSA actions from a
+// deprecated repository.
+func (pw *ProvenanceWorkflow) IsLegacy() bool {
+	return len(pw.LegacyActionsRepos) > 0
 }
 
 // Actor abstracts a user. For now it is intended to model both entities

--- a/pkg/sourcetool/models/modelsfakes/fake_vcs_backend.go
+++ b/pkg/sourcetool/models/modelsfakes/fake_vcs_backend.go
@@ -54,6 +54,20 @@ type FakeVcsBackend struct {
 		result3 models.ControlPreRemediationFn
 		result4 error
 	}
+	FindProvenanceWorkflowsStub        func(context.Context, *models.Branch) ([]*models.ProvenanceWorkflow, error)
+	findProvenanceWorkflowsMutex       sync.RWMutex
+	findProvenanceWorkflowsArgsForCall []struct {
+		arg1 context.Context
+		arg2 *models.Branch
+	}
+	findProvenanceWorkflowsReturns struct {
+		result1 []*models.ProvenanceWorkflow
+		result2 error
+	}
+	findProvenanceWorkflowsReturnsOnCall map[int]struct {
+		result1 []*models.ProvenanceWorkflow
+		result2 error
+	}
 	GetBranchControlsStub        func(context.Context, *models.Branch) (*slsa.ControlSet, error)
 	getBranchControlsMutex       sync.RWMutex
 	getBranchControlsArgsForCall []struct {
@@ -371,6 +385,71 @@ func (fake *FakeVcsBackend) ControlPrecheckReturnsOnCall(i int, result1 bool, re
 		result3 models.ControlPreRemediationFn
 		result4 error
 	}{result1, result2, result3, result4}
+}
+
+func (fake *FakeVcsBackend) FindProvenanceWorkflows(arg1 context.Context, arg2 *models.Branch) ([]*models.ProvenanceWorkflow, error) {
+	fake.findProvenanceWorkflowsMutex.Lock()
+	ret, specificReturn := fake.findProvenanceWorkflowsReturnsOnCall[len(fake.findProvenanceWorkflowsArgsForCall)]
+	fake.findProvenanceWorkflowsArgsForCall = append(fake.findProvenanceWorkflowsArgsForCall, struct {
+		arg1 context.Context
+		arg2 *models.Branch
+	}{arg1, arg2})
+	stub := fake.FindProvenanceWorkflowsStub
+	fakeReturns := fake.findProvenanceWorkflowsReturns
+	fake.recordInvocation("FindProvenanceWorkflows", []interface{}{arg1, arg2})
+	fake.findProvenanceWorkflowsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeVcsBackend) FindProvenanceWorkflowsCallCount() int {
+	fake.findProvenanceWorkflowsMutex.RLock()
+	defer fake.findProvenanceWorkflowsMutex.RUnlock()
+	return len(fake.findProvenanceWorkflowsArgsForCall)
+}
+
+func (fake *FakeVcsBackend) FindProvenanceWorkflowsCalls(stub func(context.Context, *models.Branch) ([]*models.ProvenanceWorkflow, error)) {
+	fake.findProvenanceWorkflowsMutex.Lock()
+	defer fake.findProvenanceWorkflowsMutex.Unlock()
+	fake.FindProvenanceWorkflowsStub = stub
+}
+
+func (fake *FakeVcsBackend) FindProvenanceWorkflowsArgsForCall(i int) (context.Context, *models.Branch) {
+	fake.findProvenanceWorkflowsMutex.RLock()
+	defer fake.findProvenanceWorkflowsMutex.RUnlock()
+	argsForCall := fake.findProvenanceWorkflowsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeVcsBackend) FindProvenanceWorkflowsReturns(result1 []*models.ProvenanceWorkflow, result2 error) {
+	fake.findProvenanceWorkflowsMutex.Lock()
+	defer fake.findProvenanceWorkflowsMutex.Unlock()
+	fake.FindProvenanceWorkflowsStub = nil
+	fake.findProvenanceWorkflowsReturns = struct {
+		result1 []*models.ProvenanceWorkflow
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVcsBackend) FindProvenanceWorkflowsReturnsOnCall(i int, result1 []*models.ProvenanceWorkflow, result2 error) {
+	fake.findProvenanceWorkflowsMutex.Lock()
+	defer fake.findProvenanceWorkflowsMutex.Unlock()
+	fake.FindProvenanceWorkflowsStub = nil
+	if fake.findProvenanceWorkflowsReturnsOnCall == nil {
+		fake.findProvenanceWorkflowsReturnsOnCall = make(map[int]struct {
+			result1 []*models.ProvenanceWorkflow
+			result2 error
+		})
+	}
+	fake.findProvenanceWorkflowsReturnsOnCall[i] = struct {
+		result1 []*models.ProvenanceWorkflow
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeVcsBackend) GetBranchControls(arg1 context.Context, arg2 *models.Branch) (*slsa.ControlSet, error) {

--- a/pkg/sourcetool/options/options.go
+++ b/pkg/sourcetool/options/options.go
@@ -34,7 +34,7 @@ type Options struct {
 
 	// ExpectedIssuer and ExpectedSan override the identity expected to have
 	// signed the attestations the tool verifies. When empty, the tool
-	// defaults to the SLSA source-actions workflow identity.
+	// defaults to the SLSA actions provenance workflow identity.
 	ExpectedIssuer string
 	ExpectedSan    string
 

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -330,6 +330,16 @@ func (t *Tool) ControlPrecheck(
 	return t.backend.ControlPrecheck(r, branches, config)
 }
 
+// FindProvenanceWorkflows returns the workflows in the branch that call the
+// SLSA source actions to generate provenance. Workflows still calling the
+// actions from a legacy repository are flagged so they can be updated.
+func (t *Tool) FindProvenanceWorkflows(ctx context.Context, branch *models.Branch) ([]*models.ProvenanceWorkflow, error) {
+	if branch == nil || branch.Repository == nil {
+		return nil, errors.New("repository not specified in branch")
+	}
+	return t.backend.FindProvenanceWorkflows(ctx, branch)
+}
+
 // Attester returns an attester object with the tool configuration
 func (t *Tool) Attester() *attest.Attester {
 	return t.attester

--- a/pkg/sourcetool/tool.go
+++ b/pkg/sourcetool/tool.go
@@ -61,8 +61,9 @@ func New(funcs ...ConfigFn) (*Tool, error) {
 	}
 	if t.Options.ExpectedSan != "" {
 		// When pinning a custom identity, don't accept the default
-		// migration alternates.
+		// workflow identity prefix or the migration alternates.
 		verifierOptions.ExpectedSan = t.Options.ExpectedSan
+		verifierOptions.ExpectedSanPrefix = ""
 		verifierOptions.AlternateSans = nil
 	}
 

--- a/pkg/sourcetool/tool_test.go
+++ b/pkg/sourcetool/tool_test.go
@@ -15,6 +15,39 @@ import (
 	"github.com/slsa-framework/source-tool/pkg/sourcetool/sourcetoolfakes"
 )
 
+func TestFindProvenanceWorkflows(t *testing.T) {
+	t.Parallel()
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		backend := &modelsfakes.FakeVcsBackend{}
+		backend.FindProvenanceWorkflowsReturns([]*models.ProvenanceWorkflow{
+			{Path: ".github/workflows/slsa.yml", LegacyActionsRepos: []string{"slsa-framework/source-actions"}},
+		}, nil)
+		tool := &Tool{backend: backend}
+		res, err := tool.FindProvenanceWorkflows(t.Context(), &models.Branch{Name: "main", Repository: &models.Repository{}})
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.True(t, res[0].IsLegacy())
+		require.Equal(t, 1, backend.FindProvenanceWorkflowsCallCount())
+	})
+	t.Run("no-repository", func(t *testing.T) {
+		t.Parallel()
+		backend := &modelsfakes.FakeVcsBackend{}
+		tool := &Tool{backend: backend}
+		_, err := tool.FindProvenanceWorkflows(t.Context(), &models.Branch{Name: "main"})
+		require.Error(t, err)
+		require.Equal(t, 0, backend.FindProvenanceWorkflowsCallCount())
+	})
+	t.Run("backend-fails", func(t *testing.T) {
+		t.Parallel()
+		backend := &modelsfakes.FakeVcsBackend{}
+		backend.FindProvenanceWorkflowsReturns(nil, errors.New("failed badly"))
+		tool := &Tool{backend: backend}
+		_, err := tool.FindProvenanceWorkflows(t.Context(), &models.Branch{Name: "main", Repository: &models.Repository{}})
+		require.Error(t, err)
+	})
+}
+
 func TestGetBranchControls(t *testing.T) {
 	t.Parallel()
 	t.Run("GetActiveControls-success", func(t *testing.T) {


### PR DESCRIPTION
This PR adds support to `sourcetool setup` and `sourcetool status` to detect and migrate workflows to the new actions repo. In particular, `repo` now can be re-run to update workflows to use the action from the new repo. 

We also now add better handling of the expected signer identities via the signer matcher as we now support three ids by default (the POC, source-actions and actions).